### PR TITLE
Use Bearer token to authenticate - And refresh token support

### DIFF
--- a/commvault/handler/CommvaultClient.go
+++ b/commvault/handler/CommvaultClient.go
@@ -17,6 +17,25 @@ import (
 var XML = "application/xml"
 var JSON = "application/json"
 
+func normalizeAuthToken(authToken string) string {
+	token := strings.TrimSpace(authToken)
+	if strings.HasPrefix(strings.ToLower(token), "bearer ") {
+		token = strings.TrimSpace(token[len("Bearer "):])
+	}
+	return token
+}
+
+func setAuthHeaders(req *http.Request, authToken string) {
+	token := normalizeAuthToken(authToken)
+	if token == "" {
+		return
+	}
+
+	// Keep legacy Commvault header while also supporting Metallic bearer auth.
+	req.Header.Set("AuthToken", token)
+	req.Header.Set("Authorization", "Bearer "+token)
+}
+
 func buildHttpReq(url string, method string, accept string, requestBody []byte, contentType string, authToken string, companyID int) (*http.Request, error) {
 	if !strings.HasSuffix(url, "login") {
 		LogEntry("REQUEST: ", "("+method+") "+url+"\nBODY: "+string(requestBody))
@@ -27,7 +46,7 @@ func buildHttpReq(url string, method string, accept string, requestBody []byte, 
 	}
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", accept)
-	req.Header.Set("AuthToken", authToken)
+	setAuthHeaders(req, authToken)
 	if method == "POST" {
 		req.Header.Set("operatorCompanyId", strconv.Itoa(companyID))
 	}
@@ -99,7 +118,7 @@ func makeHttpRequest(url string, method string, accept string, requestBody []byt
 	req, err := http.NewRequest(method, url, bytes.NewBuffer(requestBody))
 	req.Header.Set("Content-Type", contentType)
 	req.Header.Set("Accept", accept)
-	req.Header.Set("AuthToken", authToken)
+	setAuthHeaders(req, authToken)
 	if method == "POST" {
 		req.Header.Set("operatorCompanyId", strconv.Itoa(companyID))
 	}

--- a/commvault/handler/CommvaultClient.go
+++ b/commvault/handler/CommvaultClient.go
@@ -31,8 +31,13 @@ func setAuthHeaders(req *http.Request, authToken string) {
 		return
 	}
 
-	// Keep legacy Commvault header while also supporting Metallic bearer auth.
-	req.Header.Set("AuthToken", token)
+	// Legacy login tokens begin with QSDK and must be sent via AuthToken.
+	if strings.HasPrefix(strings.ToUpper(token), "QSDK ") {
+		req.Header.Set("AuthToken", token)
+		return
+	}
+
+	// Access tokens created via /V4/AccessToken are bearer tokens.
 	req.Header.Set("Authorization", "Bearer "+token)
 }
 
@@ -80,12 +85,22 @@ func executeHttpReq(req *http.Request) ([]byte, error) {
 	return data, nil
 }
 
-func makeHttpRequestErr(url string, method string, accept string, requestBody []byte, contentType string, authToken string, companyID int) ([]byte, error) {
+func execHttpRequestErr(url string, method string, accept string, requestBody []byte, contentType string, authToken string, companyID int) ([]byte, error) {
 	req, err := buildHttpReq(url, method, accept, requestBody, contentType, authToken, companyID)
 	if err != nil {
 		return nil, err
 	}
 	return executeHttpReq(req)
+}
+
+func makeHttpRequestErr(url string, method string, accept string, requestBody []byte, contentType string, authToken string, companyID int) ([]byte, error) {
+	data, err := execHttpRequestErr(url, method, accept, requestBody, contentType, authToken, companyID)
+	if err != nil && strings.Contains(err.Error(), "status: 401") {
+		if renewErr := RenewAccessToken(authToken); renewErr == nil {
+			return execHttpRequestErr(url, method, accept, requestBody, contentType, os.Getenv("AuthToken"), companyID)
+		}
+	}
+	return data, err
 }
 
 // makeHttpRequestBody always returns the response body, even on non-200 status codes.
@@ -109,6 +124,25 @@ func makeHttpRequestBody(url string, method string, accept string, requestBody [
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, resp.StatusCode, err
+	}
+	if resp.StatusCode == 401 {
+		if renewErr := RenewAccessToken(authToken); renewErr == nil {
+			retryReq, retryReqErr := buildHttpReq(url, method, accept, requestBody, contentType, os.Getenv("AuthToken"), companyID)
+			if retryReqErr != nil {
+				return nil, 0, retryReqErr
+			}
+			retryResp, retryErr := client.Do(retryReq)
+			if retryErr != nil {
+				return nil, 0, retryErr
+			}
+			defer retryResp.Body.Close()
+			retryData, retryReadErr := ioutil.ReadAll(retryResp.Body)
+			if retryReadErr != nil {
+				return nil, retryResp.StatusCode, retryReadErr
+			}
+			LogEntry("RESPONSE: ", string(retryData))
+			return retryData, retryResp.StatusCode, nil
+		}
 	}
 	LogEntry("RESPONSE: ", string(data))
 	return data, resp.StatusCode, nil
@@ -139,6 +173,30 @@ func makeHttpRequest(url string, method string, accept string, requestBody []byt
 	data, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		panic(err)
+	}
+	if resp.StatusCode == 401 {
+		if renewErr := RenewAccessToken(authToken); renewErr == nil {
+			retryReq, retryReqErr := http.NewRequest(method, url, bytes.NewBuffer(requestBody))
+			if retryReqErr != nil {
+				panic(retryReqErr)
+			}
+			retryReq.Header.Set("Content-Type", contentType)
+			retryReq.Header.Set("Accept", accept)
+			setAuthHeaders(retryReq, os.Getenv("AuthToken"))
+			if method == "POST" {
+				retryReq.Header.Set("operatorCompanyId", strconv.Itoa(companyID))
+			}
+			retryResp, retryErr := client.Do(retryReq)
+			if retryErr != nil {
+				panic(retryErr)
+			}
+			defer retryResp.Body.Close()
+			retryData, retryReadErr := ioutil.ReadAll(retryResp.Body)
+			if retryReadErr != nil {
+				panic(retryReadErr)
+			}
+			return retryData
+		}
 	}
 	return data
 }

--- a/commvault/handler/LoginHandler.go
+++ b/commvault/handler/LoginHandler.go
@@ -1,9 +1,15 @@
 package handler
 
 import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
+	"io"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -19,6 +25,12 @@ type TokenCacheEntry struct {
 	RefreshToken string `json:"refreshToken"`
 	CreatedAt    int64  `json:"createdAt"`
 	ExpiresAt    int64  `json:"expiresAt"`
+}
+
+type EncryptedTokenCache struct {
+	Version    int    `json:"version"`
+	Nonce      string `json:"nonce"`
+	Ciphertext string `json:"ciphertext"`
 }
 
 type AccessTokenCreateReq struct {
@@ -90,19 +102,20 @@ func getCachedTokens() *TokenCacheEntry {
 		return nil
 	}
 
-	var cache TokenCacheEntry
-	if err := json.Unmarshal(data, &cache); err != nil {
-		// Corrupted cache - ignore and return nil
-		return nil
+	cache, decrypted := decryptCachedTokens(data)
+	if !decrypted {
+		// Backward compatibility: accept legacy plaintext cache and migrate it to encrypted format.
+		if err := json.Unmarshal(data, &cache); err != nil {
+			return nil
+		}
+		_ = saveCachedTokenEntry(&cache)
+		if !isCacheValid(&cache) {
+			return nil
+		}
+		return &cache
 	}
 
-	// Check if tokens are still valid (not expiring in next 5 minutes)
-	now := time.Now().Unix()
-	if cache.ExpiresAt > 0 && now > cache.ExpiresAt-300 { // 5 min buffer
-		return nil
-	}
-
-	if cache.AccessToken == "" || cache.RefreshToken == "" {
+	if !isCacheValid(&cache) {
 		return nil
 	}
 
@@ -117,11 +130,6 @@ func saveCachedTokens(accessToken, refreshToken string) error {
 		return nil
 	}
 
-	cacheFile, err := getCacheFilePath()
-	if err != nil {
-		return nil
-	}
-
 	cache := TokenCacheEntry{
 		AccessToken:  accessToken,
 		RefreshToken: refreshToken,
@@ -129,8 +137,18 @@ func saveCachedTokens(accessToken, refreshToken string) error {
 		ExpiresAt:    time.Now().Add(2 * time.Hour).Unix(), // Access tokens valid ~2 hours
 	}
 
-	data, err := json.MarshalIndent(&cache, "", "  ")
+	return saveCachedTokenEntry(&cache)
+}
+
+func saveCachedTokenEntry(cache *TokenCacheEntry) error {
+	cacheFile, err := getCacheFilePath()
 	if err != nil {
+		return nil
+	}
+
+	data, err := encryptCachedTokens(cache)
+	if err != nil {
+		// Non-blocking: if encryption fails, continue without cache.
 		return nil
 	}
 
@@ -141,6 +159,118 @@ func saveCachedTokens(accessToken, refreshToken string) error {
 	}
 
 	return nil
+}
+
+func isCacheValid(cache *TokenCacheEntry) bool {
+	if cache == nil {
+		return false
+	}
+
+	now := time.Now().Unix()
+	if cache.ExpiresAt > 0 && now > cache.ExpiresAt-300 {
+		return false
+	}
+
+	if cache.AccessToken == "" || cache.RefreshToken == "" {
+		return false
+	}
+
+	return true
+}
+
+func cacheEncryptionKey() ([]byte, error) {
+	bootstrapToken := normalizeAuthToken(os.Getenv("CV_BOOTSTRAP_TOKEN"))
+	if bootstrapToken == "" {
+		bootstrapToken = normalizeAuthToken(os.Getenv("CV_API_TOKEN"))
+	}
+	if bootstrapToken == "" {
+		return nil, fmt.Errorf("cache encryption key unavailable")
+	}
+
+	baseURL := strings.TrimSpace(strings.TrimRight(strings.ToLower(os.Getenv("CV_CSIP")), "/"))
+	raw := "commvault-cache-v1|" + baseURL + "|" + bootstrapToken
+	sum := sha256.Sum256([]byte(raw))
+	return sum[:], nil
+}
+
+func encryptCachedTokens(cache *TokenCacheEntry) ([]byte, error) {
+	key, err := cacheEncryptionKey()
+	if err != nil {
+		return nil, err
+	}
+
+	plain, err := json.Marshal(cache)
+	if err != nil {
+		return nil, err
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return nil, err
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return nil, err
+	}
+
+	nonce := make([]byte, gcm.NonceSize())
+	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
+		return nil, err
+	}
+
+	ciphertext := gcm.Seal(nil, nonce, plain, nil)
+	enc := EncryptedTokenCache{
+		Version:    1,
+		Nonce:      base64.StdEncoding.EncodeToString(nonce),
+		Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
+	}
+
+	return json.Marshal(enc)
+}
+
+func decryptCachedTokens(data []byte) (TokenCacheEntry, bool) {
+	var enc EncryptedTokenCache
+	if err := json.Unmarshal(data, &enc); err != nil {
+		return TokenCacheEntry{}, false
+	}
+	if enc.Version != 1 || enc.Nonce == "" || enc.Ciphertext == "" {
+		return TokenCacheEntry{}, false
+	}
+
+	key, err := cacheEncryptionKey()
+	if err != nil {
+		return TokenCacheEntry{}, false
+	}
+
+	nonce, err := base64.StdEncoding.DecodeString(enc.Nonce)
+	if err != nil {
+		return TokenCacheEntry{}, false
+	}
+	ciphertext, err := base64.StdEncoding.DecodeString(enc.Ciphertext)
+	if err != nil {
+		return TokenCacheEntry{}, false
+	}
+
+	block, err := aes.NewCipher(key)
+	if err != nil {
+		return TokenCacheEntry{}, false
+	}
+	gcm, err := cipher.NewGCM(block)
+	if err != nil {
+		return TokenCacheEntry{}, false
+	}
+
+	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
+	if err != nil {
+		return TokenCacheEntry{}, false
+	}
+
+	var cache TokenCacheEntry
+	if err := json.Unmarshal(plain, &cache); err != nil {
+		return TokenCacheEntry{}, false
+	}
+
+	return cache, true
 }
 
 // TryUseCachedTokens attempts to use cached tokens if they're still valid.

--- a/commvault/handler/LoginHandler.go
+++ b/commvault/handler/LoginHandler.go
@@ -6,7 +6,326 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
 )
+
+var tokenRenewMutex sync.Mutex
+
+type TokenCacheEntry struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+	CreatedAt    int64  `json:"createdAt"`
+	ExpiresAt    int64  `json:"expiresAt"`
+}
+
+type AccessTokenCreateReq struct {
+	TokenName               string `json:"tokenName"`
+	RenewableUntilTimestamp int64  `json:"renewableUntilTimestamp"`
+	TokenExpiryTimestamp    int64  `json:"tokenExpiryTimestamp"`
+	EnableIPAllowList       bool   `json:"enableIPAllowListFeature"`
+}
+
+type AccessTokenError struct {
+	ErrorMessage string `json:"errorMessage"`
+	ErrorCode    int    `json:"errorCode"`
+}
+
+type AccessTokenInfo struct {
+	AccessToken string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+}
+
+type AccessTokenCreateResp struct {
+	Error     AccessTokenError `json:"error"`
+	TokenInfo AccessTokenInfo  `json:"tokenInfo"`
+}
+
+type AccessTokenRenewReq struct {
+	AccessToken  string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+}
+
+type AccessTokenRenewResp struct {
+	AccessToken string `json:"accessToken"`
+	RefreshToken string `json:"refreshToken"`
+}
+
+// getCacheFilePath returns the path to the token cache file: ~/.commvault/tokens.json
+func getCacheFilePath() (string, error) {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("failed to get home directory: %w", err)
+	}
+	cacheDir := filepath.Join(homeDir, ".commvault")
+	return filepath.Join(cacheDir, "tokens.json"), nil
+}
+
+// ensureCacheDir creates ~/.commvault directory if it doesn't exist
+func ensureCacheDir() error {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return fmt.Errorf("failed to get home directory: %w", err)
+	}
+	cacheDir := filepath.Join(homeDir, ".commvault")
+	if err := os.MkdirAll(cacheDir, 0700); err != nil {
+		return fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
+	}
+	return nil
+}
+
+// getCachedTokens reads and validates the token cache file.
+// Returns nil if cache doesn't exist, is invalid JSON, or tokens are expired.
+func getCachedTokens() *TokenCacheEntry {
+	cacheFile, err := getCacheFilePath()
+	if err != nil {
+		return nil
+	}
+
+	data, err := os.ReadFile(cacheFile)
+	if err != nil {
+		// File doesn't exist or can't be read - cache miss
+		return nil
+	}
+
+	var cache TokenCacheEntry
+	if err := json.Unmarshal(data, &cache); err != nil {
+		// Corrupted cache - ignore and return nil
+		return nil
+	}
+
+	// Check if tokens are still valid (not expiring in next 5 minutes)
+	now := time.Now().Unix()
+	if cache.ExpiresAt > 0 && now > cache.ExpiresAt-300 { // 5 min buffer
+		return nil
+	}
+
+	if cache.AccessToken == "" || cache.RefreshToken == "" {
+		return nil
+	}
+
+	return &cache
+}
+
+// saveCachedTokens writes tokens to ~/.commvault/tokens.json
+// Token expiry is set to 2 hours from now (Commvault's access token lifetime)
+func saveCachedTokens(accessToken, refreshToken string) error {
+	if err := ensureCacheDir(); err != nil {
+		// Non-blocking: if cache fails, just continue without caching
+		return nil
+	}
+
+	cacheFile, err := getCacheFilePath()
+	if err != nil {
+		return nil
+	}
+
+	cache := TokenCacheEntry{
+		AccessToken:  accessToken,
+		RefreshToken: refreshToken,
+		CreatedAt:    time.Now().Unix(),
+		ExpiresAt:    time.Now().Add(2 * time.Hour).Unix(), // Access tokens valid ~2 hours
+	}
+
+	data, err := json.MarshalIndent(&cache, "", "  ")
+	if err != nil {
+		return nil
+	}
+
+	// Write with restricted permissions (user only)
+	if err := os.WriteFile(cacheFile, data, 0600); err != nil {
+		// Non-blocking: cache write failure doesn't break provider
+		return nil
+	}
+
+	return nil
+}
+
+// TryUseCachedTokens attempts to use cached tokens if they're still valid.
+// Returns (true, nil) if cache was loaded and set in environment.
+// Returns (false, nil) if cache doesn't exist or is expired.
+// Returns (false, err) if there's an error reading cache.
+func TryUseCachedTokens() (bool, error) {
+	cache := getCachedTokens()
+	if cache == nil {
+		return false, nil
+	}
+
+	// Cache is valid - load into environment
+	setRuntimeTokens(cache.AccessToken, cache.RefreshToken)
+	return true, nil
+}
+
+func createAccessTokenPair(bootstrapToken string, tokenName string) (*AccessTokenCreateResp, error) {
+	reqBodyObj := AccessTokenCreateReq{
+		TokenName:               tokenName,
+		RenewableUntilTimestamp: time.Now().Add(30 * 24 * time.Hour).Unix(),
+		TokenExpiryTimestamp:    0,
+		EnableIPAllowList:       false,
+	}
+	reqBody, _ := json.Marshal(&reqBodyObj)
+
+	url := buildV4TokenURL("/AccessToken")
+	respBody, err := execHttpRequestErr(url, http.MethodPost, JSON, reqBody, JSON, bootstrapToken, 0)
+	if err != nil {
+		return nil, fmt.Errorf("create access token failed: %w", err)
+	}
+
+	var resp AccessTokenCreateResp
+	if jsonErr := json.Unmarshal(respBody, &resp); jsonErr != nil {
+		return nil, fmt.Errorf("create access token parse failed: %w", jsonErr)
+	}
+	if resp.Error.ErrorCode != 0 {
+		return nil, fmt.Errorf("create access token error: code=%d message=%s", resp.Error.ErrorCode, resp.Error.ErrorMessage)
+	}
+
+	return &resp, nil
+}
+
+func buildV4TokenURL(path string) string {
+	base := strings.TrimRight(os.Getenv("CV_CSIP"), "/")
+	if strings.HasSuffix(strings.ToLower(base), "/v4") {
+		return base + path
+	}
+	return base + "/V4" + path
+}
+
+func setRuntimeTokens(accessToken string, refreshToken string) {
+	if accessToken != "" {
+		os.Setenv("AuthToken", accessToken)
+	}
+	if refreshToken != "" {
+		os.Setenv("CV_REFRESH_TOKEN", refreshToken)
+	}
+}
+
+func fallbackBootstrapOnRenewFailure() error {
+	bootstrapToken := normalizeAuthToken(os.Getenv("CV_BOOTSTRAP_TOKEN"))
+	if bootstrapToken == "" {
+		return fmt.Errorf("bootstrap token is empty")
+	}
+	if err := CreateAccessTokenWithBootstrapToken(bootstrapToken); err != nil {
+		return fmt.Errorf("bootstrap fallback failed: %w", err)
+	}
+	return nil
+}
+
+// CreateAccessTokenWithBootstrapToken creates a new access token pair from a bootstrap token.
+// It calls POST /V4/AccessToken with a renewable-until timestamp set to 30 days from now.
+func CreateAccessTokenWithBootstrapToken(bootstrapToken string) error {
+	bootstrapToken = normalizeAuthToken(bootstrapToken)
+	if bootstrapToken == "" {
+		return fmt.Errorf("api_token is empty")
+	}
+
+	resp, err := createAccessTokenPair(bootstrapToken, "AdminToken")
+	if err != nil {
+		if strings.Contains(err.Error(), "Token name already present") {
+			fallbackName := fmt.Sprintf("AdminToken-%d", time.Now().Unix())
+			resp, err = createAccessTokenPair(bootstrapToken, fallbackName)
+		}
+		if err != nil {
+			return err
+		}
+	}
+
+	if resp.TokenInfo.AccessToken == "" || resp.TokenInfo.RefreshToken == "" {
+		return fmt.Errorf("create access token returned empty access or refresh token")
+	}
+
+	setRuntimeTokens(resp.TokenInfo.AccessToken, resp.TokenInfo.RefreshToken)
+	// Save to cache for next provider run (non-blocking)
+	saveCachedTokens(resp.TokenInfo.AccessToken, resp.TokenInfo.RefreshToken)
+	return nil
+}
+
+// TryRenewWithExpiredTokenAndRefresh attempts to renew an expired bootstrap token using a refresh token.
+// This is used on provider startup when bootstrap token creation fails with 401.
+func TryRenewWithExpiredTokenAndRefresh(expiredToken string, refreshToken string) error {
+	expiredToken = normalizeAuthToken(expiredToken)
+	refreshToken = normalizeAuthToken(refreshToken)
+
+	if expiredToken == "" || refreshToken == "" {
+		return fmt.Errorf("both expired token and refresh token are required for renewal")
+	}
+
+	reqBodyObj := AccessTokenRenewReq{AccessToken: expiredToken, RefreshToken: refreshToken}
+	reqBody, _ := json.Marshal(&reqBodyObj)
+
+	url := buildV4TokenURL("/AccessToken/Renew")
+	respBody, err := execHttpRequestErr(url, http.MethodPost, JSON, reqBody, JSON, expiredToken, 0)
+	if err != nil {
+		return fmt.Errorf("renew with expired token failed: %w", err)
+	}
+
+	var resp AccessTokenRenewResp
+	if jsonErr := json.Unmarshal(respBody, &resp); jsonErr != nil {
+		return fmt.Errorf("renew with expired token parse failed: %w", jsonErr)
+	}
+	if resp.AccessToken == "" || resp.RefreshToken == "" {
+		return fmt.Errorf("renew with expired token returned empty access or refresh token")
+	}
+
+	setRuntimeTokens(resp.AccessToken, resp.RefreshToken)
+	// Save to cache for next provider run (non-blocking)
+	saveCachedTokens(resp.AccessToken, resp.RefreshToken)
+	return nil
+}
+
+// RenewAccessToken renews the active token pair using POST /V4/AccessToken/Renew.
+// It updates both access and refresh token in process environment after successful renewal.
+func RenewAccessToken(expiredAccessToken string) error {
+	tokenRenewMutex.Lock()
+	defer tokenRenewMutex.Unlock()
+
+	currentToken := normalizeAuthToken(os.Getenv("AuthToken"))
+	if currentToken != "" && currentToken != normalizeAuthToken(expiredAccessToken) {
+		return nil
+	}
+
+	refreshToken := normalizeAuthToken(os.Getenv("CV_REFRESH_TOKEN"))
+	if refreshToken == "" {
+		if fallbackErr := fallbackBootstrapOnRenewFailure(); fallbackErr == nil {
+			return nil
+		}
+		return fmt.Errorf("refresh token is empty and bootstrap fallback unavailable")
+	}
+
+	accessToken := normalizeAuthToken(expiredAccessToken)
+	if accessToken == "" {
+		accessToken = currentToken
+	}
+	if accessToken == "" {
+		return fmt.Errorf("access token is empty")
+	}
+
+	reqBodyObj := AccessTokenRenewReq{AccessToken: accessToken, RefreshToken: refreshToken}
+	reqBody, _ := json.Marshal(&reqBodyObj)
+
+	url := buildV4TokenURL("/AccessToken/Renew")
+	respBody, err := execHttpRequestErr(url, http.MethodPost, JSON, reqBody, JSON, accessToken, 0)
+	if err != nil {
+		if fallbackErr := fallbackBootstrapOnRenewFailure(); fallbackErr == nil {
+			return nil
+		}
+		return fmt.Errorf("renew access token failed: %w", err)
+	}
+
+	var resp AccessTokenRenewResp
+	if jsonErr := json.Unmarshal(respBody, &resp); jsonErr != nil {
+		return fmt.Errorf("renew access token parse failed: %w", jsonErr)
+	}
+	if resp.AccessToken == "" || resp.RefreshToken == "" {
+		return fmt.Errorf("renew access token returned empty access or refresh token")
+	}
+
+	setRuntimeTokens(resp.AccessToken, resp.RefreshToken)
+	// Save to cache for next provider run (non-blocking)
+	saveCachedTokens(resp.AccessToken, resp.RefreshToken)
+	return nil
+}
 
 func GenerateAuthToken(username string, password string) string {
 	url := os.Getenv("CV_CSIP") + "/Login"

--- a/commvault/handler/LoginHandler.go
+++ b/commvault/handler/LoginHandler.go
@@ -12,6 +12,7 @@ import (
 	"io"
 	"net/http"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"sync"
@@ -331,8 +332,57 @@ func setRuntimeTokens(accessToken string, refreshToken string) {
 	}
 }
 
+func FetchAzureKeyVaultSecret(secretName string) (string, error) {
+	vaultName := strings.TrimSpace(os.Getenv("CV_KEY_VAULT_NAME"))
+	secretName = strings.TrimSpace(secretName)
+	if vaultName == "" || secretName == "" {
+		return "", nil
+	}
+
+	cmd := exec.Command("az", "keyvault", "secret", "show", "--vault-name", vaultName, "--name", secretName, "--query", "value", "-o", "tsv")
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		msg := strings.TrimSpace(string(out))
+		if msg != "" {
+			return "", fmt.Errorf("failed to read secret %s from key vault %s: %w: %s", secretName, vaultName, err, msg)
+		}
+		return "", fmt.Errorf("failed to read secret %s from key vault %s: %w", secretName, vaultName, err)
+	}
+
+	return normalizeAuthToken(strings.TrimSpace(string(out))), nil
+}
+
+func TryLoadRefreshTokenFromKeyVault() (string, error) {
+	secretName := os.Getenv("CV_KEY_VAULT_REFRESH_TOKEN_SECRET")
+	refreshToken, err := FetchAzureKeyVaultSecret(secretName)
+	if err != nil {
+		return "", err
+	}
+	if refreshToken != "" {
+		os.Setenv("CV_REFRESH_TOKEN", refreshToken)
+	}
+	return refreshToken, nil
+}
+
+func tryLoadBootstrapTokenFromKeyVault() (string, error) {
+	secretName := os.Getenv("CV_KEY_VAULT_API_TOKEN_SECRET")
+	bootstrapToken, err := FetchAzureKeyVaultSecret(secretName)
+	if err != nil {
+		return "", err
+	}
+	if bootstrapToken != "" {
+		os.Setenv("CV_BOOTSTRAP_TOKEN", bootstrapToken)
+	}
+	return bootstrapToken, nil
+}
+
 func fallbackBootstrapOnRenewFailure() error {
 	bootstrapToken := normalizeAuthToken(os.Getenv("CV_BOOTSTRAP_TOKEN"))
+	if bootstrapToken == "" {
+		if kvBootstrapToken, kvErr := tryLoadBootstrapTokenFromKeyVault(); kvErr == nil && kvBootstrapToken != "" {
+			bootstrapToken = kvBootstrapToken
+		}
+	}
 	if bootstrapToken == "" {
 		return fmt.Errorf("bootstrap token is empty")
 	}
@@ -387,15 +437,15 @@ func TryRenewWithExpiredTokenAndRefresh(expiredToken string, refreshToken string
 	url := buildV4TokenURL("/AccessToken/Renew")
 	respBody, err := execHttpRequestErr(url, http.MethodPost, JSON, reqBody, JSON, expiredToken, 0)
 	if err != nil {
-		return fmt.Errorf("renew with expired token failed: %w", err)
+		return fmt.Errorf("renew with token failed: %w", err)
 	}
 
 	var resp AccessTokenRenewResp
 	if jsonErr := json.Unmarshal(respBody, &resp); jsonErr != nil {
-		return fmt.Errorf("renew with expired token parse failed: %w", jsonErr)
+		return fmt.Errorf("renew with token parse failed: %w", jsonErr)
 	}
 	if resp.AccessToken == "" || resp.RefreshToken == "" {
-		return fmt.Errorf("renew with expired token returned empty access or refresh token")
+		return fmt.Errorf("renew with token returned empty access or refresh token")
 	}
 
 	setRuntimeTokens(resp.AccessToken, resp.RefreshToken)
@@ -417,6 +467,11 @@ func RenewAccessToken(expiredAccessToken string) error {
 
 	refreshToken := normalizeAuthToken(os.Getenv("CV_REFRESH_TOKEN"))
 	if refreshToken == "" {
+		if kvRefreshToken, kvErr := TryLoadRefreshTokenFromKeyVault(); kvErr == nil && kvRefreshToken != "" {
+			refreshToken = kvRefreshToken
+		}
+	}
+	if refreshToken == "" {
 		if fallbackErr := fallbackBootstrapOnRenewFailure(); fallbackErr == nil {
 			return nil
 		}
@@ -436,6 +491,13 @@ func RenewAccessToken(expiredAccessToken string) error {
 
 	url := buildV4TokenURL("/AccessToken/Renew")
 	respBody, err := execHttpRequestErr(url, http.MethodPost, JSON, reqBody, JSON, accessToken, 0)
+	if err != nil {
+		if kvRefreshToken, kvErr := TryLoadRefreshTokenFromKeyVault(); kvErr == nil && kvRefreshToken != "" && kvRefreshToken != refreshToken {
+			retryReqBodyObj := AccessTokenRenewReq{AccessToken: accessToken, RefreshToken: kvRefreshToken}
+			retryReqBody, _ := json.Marshal(&retryReqBodyObj)
+			respBody, err = execHttpRequestErr(url, http.MethodPost, JSON, retryReqBody, JSON, accessToken, 0)
+		}
+	}
 	if err != nil {
 		if fallbackErr := fallbackBootstrapOnRenewFailure(); fallbackErr == nil {
 			return nil

--- a/commvault/handler/LoginHandler.go
+++ b/commvault/handler/LoginHandler.go
@@ -1,38 +1,18 @@
 package handler
 
 import (
-	"crypto/aes"
-	"crypto/cipher"
-	"crypto/rand"
-	"crypto/sha256"
-	"encoding/base64"
 	"encoding/json"
 	"encoding/xml"
 	"fmt"
-	"io"
 	"net/http"
 	"os"
 	"os/exec"
-	"path/filepath"
 	"strings"
 	"sync"
 	"time"
 )
 
 var tokenRenewMutex sync.Mutex
-
-type TokenCacheEntry struct {
-	AccessToken  string `json:"accessToken"`
-	RefreshToken string `json:"refreshToken"`
-	CreatedAt    int64  `json:"createdAt"`
-	ExpiresAt    int64  `json:"expiresAt"`
-}
-
-type EncryptedTokenCache struct {
-	Version    int    `json:"version"`
-	Nonce      string `json:"nonce"`
-	Ciphertext string `json:"ciphertext"`
-}
 
 type AccessTokenCreateReq struct {
 	TokenName               string `json:"tokenName"`
@@ -64,229 +44,6 @@ type AccessTokenRenewReq struct {
 type AccessTokenRenewResp struct {
 	AccessToken string `json:"accessToken"`
 	RefreshToken string `json:"refreshToken"`
-}
-
-// getCacheFilePath returns the path to the token cache file: ~/.commvault/tokens.json
-func getCacheFilePath() (string, error) {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return "", fmt.Errorf("failed to get home directory: %w", err)
-	}
-	cacheDir := filepath.Join(homeDir, ".commvault")
-	return filepath.Join(cacheDir, "tokens.json"), nil
-}
-
-// ensureCacheDir creates ~/.commvault directory if it doesn't exist
-func ensureCacheDir() error {
-	homeDir, err := os.UserHomeDir()
-	if err != nil {
-		return fmt.Errorf("failed to get home directory: %w", err)
-	}
-	cacheDir := filepath.Join(homeDir, ".commvault")
-	if err := os.MkdirAll(cacheDir, 0700); err != nil {
-		return fmt.Errorf("failed to create cache directory %s: %w", cacheDir, err)
-	}
-	return nil
-}
-
-// getCachedTokens reads and validates the token cache file.
-// Returns nil if cache doesn't exist, is invalid JSON, or tokens are expired.
-func getCachedTokens() *TokenCacheEntry {
-	cacheFile, err := getCacheFilePath()
-	if err != nil {
-		return nil
-	}
-
-	data, err := os.ReadFile(cacheFile)
-	if err != nil {
-		// File doesn't exist or can't be read - cache miss
-		return nil
-	}
-
-	cache, decrypted := decryptCachedTokens(data)
-	if !decrypted {
-		// Backward compatibility: accept legacy plaintext cache and migrate it to encrypted format.
-		if err := json.Unmarshal(data, &cache); err != nil {
-			return nil
-		}
-		_ = saveCachedTokenEntry(&cache)
-		if !isCacheValid(&cache) {
-			return nil
-		}
-		return &cache
-	}
-
-	if !isCacheValid(&cache) {
-		return nil
-	}
-
-	return &cache
-}
-
-// saveCachedTokens writes tokens to ~/.commvault/tokens.json
-// Token expiry is set to 2 hours from now (Commvault's access token lifetime)
-func saveCachedTokens(accessToken, refreshToken string) error {
-	if err := ensureCacheDir(); err != nil {
-		// Non-blocking: if cache fails, just continue without caching
-		return nil
-	}
-
-	cache := TokenCacheEntry{
-		AccessToken:  accessToken,
-		RefreshToken: refreshToken,
-		CreatedAt:    time.Now().Unix(),
-		ExpiresAt:    time.Now().Add(2 * time.Hour).Unix(), // Access tokens valid ~2 hours
-	}
-
-	return saveCachedTokenEntry(&cache)
-}
-
-func saveCachedTokenEntry(cache *TokenCacheEntry) error {
-	cacheFile, err := getCacheFilePath()
-	if err != nil {
-		return nil
-	}
-
-	data, err := encryptCachedTokens(cache)
-	if err != nil {
-		// Non-blocking: if encryption fails, continue without cache.
-		return nil
-	}
-
-	// Write with restricted permissions (user only)
-	if err := os.WriteFile(cacheFile, data, 0600); err != nil {
-		// Non-blocking: cache write failure doesn't break provider
-		return nil
-	}
-
-	return nil
-}
-
-func isCacheValid(cache *TokenCacheEntry) bool {
-	if cache == nil {
-		return false
-	}
-
-	now := time.Now().Unix()
-	if cache.ExpiresAt > 0 && now > cache.ExpiresAt-300 {
-		return false
-	}
-
-	if cache.AccessToken == "" || cache.RefreshToken == "" {
-		return false
-	}
-
-	return true
-}
-
-func cacheEncryptionKey() ([]byte, error) {
-	bootstrapToken := normalizeAuthToken(os.Getenv("CV_BOOTSTRAP_TOKEN"))
-	if bootstrapToken == "" {
-		bootstrapToken = normalizeAuthToken(os.Getenv("CV_API_TOKEN"))
-	}
-	if bootstrapToken == "" {
-		return nil, fmt.Errorf("cache encryption key unavailable")
-	}
-
-	baseURL := strings.TrimSpace(strings.TrimRight(strings.ToLower(os.Getenv("CV_CSIP")), "/"))
-	raw := "commvault-cache-v1|" + baseURL + "|" + bootstrapToken
-	sum := sha256.Sum256([]byte(raw))
-	return sum[:], nil
-}
-
-func encryptCachedTokens(cache *TokenCacheEntry) ([]byte, error) {
-	key, err := cacheEncryptionKey()
-	if err != nil {
-		return nil, err
-	}
-
-	plain, err := json.Marshal(cache)
-	if err != nil {
-		return nil, err
-	}
-
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return nil, err
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return nil, err
-	}
-
-	nonce := make([]byte, gcm.NonceSize())
-	if _, err := io.ReadFull(rand.Reader, nonce); err != nil {
-		return nil, err
-	}
-
-	ciphertext := gcm.Seal(nil, nonce, plain, nil)
-	enc := EncryptedTokenCache{
-		Version:    1,
-		Nonce:      base64.StdEncoding.EncodeToString(nonce),
-		Ciphertext: base64.StdEncoding.EncodeToString(ciphertext),
-	}
-
-	return json.Marshal(enc)
-}
-
-func decryptCachedTokens(data []byte) (TokenCacheEntry, bool) {
-	var enc EncryptedTokenCache
-	if err := json.Unmarshal(data, &enc); err != nil {
-		return TokenCacheEntry{}, false
-	}
-	if enc.Version != 1 || enc.Nonce == "" || enc.Ciphertext == "" {
-		return TokenCacheEntry{}, false
-	}
-
-	key, err := cacheEncryptionKey()
-	if err != nil {
-		return TokenCacheEntry{}, false
-	}
-
-	nonce, err := base64.StdEncoding.DecodeString(enc.Nonce)
-	if err != nil {
-		return TokenCacheEntry{}, false
-	}
-	ciphertext, err := base64.StdEncoding.DecodeString(enc.Ciphertext)
-	if err != nil {
-		return TokenCacheEntry{}, false
-	}
-
-	block, err := aes.NewCipher(key)
-	if err != nil {
-		return TokenCacheEntry{}, false
-	}
-	gcm, err := cipher.NewGCM(block)
-	if err != nil {
-		return TokenCacheEntry{}, false
-	}
-
-	plain, err := gcm.Open(nil, nonce, ciphertext, nil)
-	if err != nil {
-		return TokenCacheEntry{}, false
-	}
-
-	var cache TokenCacheEntry
-	if err := json.Unmarshal(plain, &cache); err != nil {
-		return TokenCacheEntry{}, false
-	}
-
-	return cache, true
-}
-
-// TryUseCachedTokens attempts to use cached tokens if they're still valid.
-// Returns (true, nil) if cache was loaded and set in environment.
-// Returns (false, nil) if cache doesn't exist or is expired.
-// Returns (false, err) if there's an error reading cache.
-func TryUseCachedTokens() (bool, error) {
-	cache := getCachedTokens()
-	if cache == nil {
-		return false, nil
-	}
-
-	// Cache is valid - load into environment
-	setRuntimeTokens(cache.AccessToken, cache.RefreshToken)
-	return true, nil
 }
 
 func createAccessTokenPair(bootstrapToken string, tokenName string) (*AccessTokenCreateResp, error) {
@@ -416,8 +173,6 @@ func CreateAccessTokenWithBootstrapToken(bootstrapToken string) error {
 	}
 
 	setRuntimeTokens(resp.TokenInfo.AccessToken, resp.TokenInfo.RefreshToken)
-	// Save to cache for next provider run (non-blocking)
-	saveCachedTokens(resp.TokenInfo.AccessToken, resp.TokenInfo.RefreshToken)
 	return nil
 }
 
@@ -449,8 +204,6 @@ func TryRenewWithExpiredTokenAndRefresh(expiredToken string, refreshToken string
 	}
 
 	setRuntimeTokens(resp.AccessToken, resp.RefreshToken)
-	// Save to cache for next provider run (non-blocking)
-	saveCachedTokens(resp.AccessToken, resp.RefreshToken)
 	return nil
 }
 
@@ -514,8 +267,6 @@ func RenewAccessToken(expiredAccessToken string) error {
 	}
 
 	setRuntimeTokens(resp.AccessToken, resp.RefreshToken)
-	// Save to cache for next provider run (non-blocking)
-	saveCachedTokens(resp.AccessToken, resp.RefreshToken)
 	return nil
 }
 

--- a/commvault/handler/LoginHandler.go
+++ b/commvault/handler/LoginHandler.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"net/http"
 	"os"
-	"os/exec"
 	"strings"
 	"sync"
 	"time"
@@ -89,57 +88,8 @@ func setRuntimeTokens(accessToken string, refreshToken string) {
 	}
 }
 
-func FetchAzureKeyVaultSecret(secretName string) (string, error) {
-	vaultName := strings.TrimSpace(os.Getenv("CV_KEY_VAULT_NAME"))
-	secretName = strings.TrimSpace(secretName)
-	if vaultName == "" || secretName == "" {
-		return "", nil
-	}
-
-	cmd := exec.Command("az", "keyvault", "secret", "show", "--vault-name", vaultName, "--name", secretName, "--query", "value", "-o", "tsv")
-	out, err := cmd.CombinedOutput()
-	if err != nil {
-		msg := strings.TrimSpace(string(out))
-		if msg != "" {
-			return "", fmt.Errorf("failed to read secret %s from key vault %s: %w: %s", secretName, vaultName, err, msg)
-		}
-		return "", fmt.Errorf("failed to read secret %s from key vault %s: %w", secretName, vaultName, err)
-	}
-
-	return normalizeAuthToken(strings.TrimSpace(string(out))), nil
-}
-
-func TryLoadRefreshTokenFromKeyVault() (string, error) {
-	secretName := os.Getenv("CV_KEY_VAULT_REFRESH_TOKEN_SECRET")
-	refreshToken, err := FetchAzureKeyVaultSecret(secretName)
-	if err != nil {
-		return "", err
-	}
-	if refreshToken != "" {
-		os.Setenv("CV_REFRESH_TOKEN", refreshToken)
-	}
-	return refreshToken, nil
-}
-
-func tryLoadBootstrapTokenFromKeyVault() (string, error) {
-	secretName := os.Getenv("CV_KEY_VAULT_API_TOKEN_SECRET")
-	bootstrapToken, err := FetchAzureKeyVaultSecret(secretName)
-	if err != nil {
-		return "", err
-	}
-	if bootstrapToken != "" {
-		os.Setenv("CV_BOOTSTRAP_TOKEN", bootstrapToken)
-	}
-	return bootstrapToken, nil
-}
-
 func fallbackBootstrapOnRenewFailure() error {
 	bootstrapToken := normalizeAuthToken(os.Getenv("CV_BOOTSTRAP_TOKEN"))
-	if bootstrapToken == "" {
-		if kvBootstrapToken, kvErr := tryLoadBootstrapTokenFromKeyVault(); kvErr == nil && kvBootstrapToken != "" {
-			bootstrapToken = kvBootstrapToken
-		}
-	}
 	if bootstrapToken == "" {
 		return fmt.Errorf("bootstrap token is empty")
 	}
@@ -220,11 +170,6 @@ func RenewAccessToken(expiredAccessToken string) error {
 
 	refreshToken := normalizeAuthToken(os.Getenv("CV_REFRESH_TOKEN"))
 	if refreshToken == "" {
-		if kvRefreshToken, kvErr := TryLoadRefreshTokenFromKeyVault(); kvErr == nil && kvRefreshToken != "" {
-			refreshToken = kvRefreshToken
-		}
-	}
-	if refreshToken == "" {
 		if fallbackErr := fallbackBootstrapOnRenewFailure(); fallbackErr == nil {
 			return nil
 		}
@@ -244,13 +189,6 @@ func RenewAccessToken(expiredAccessToken string) error {
 
 	url := buildV4TokenURL("/AccessToken/Renew")
 	respBody, err := execHttpRequestErr(url, http.MethodPost, JSON, reqBody, JSON, accessToken, 0)
-	if err != nil {
-		if kvRefreshToken, kvErr := TryLoadRefreshTokenFromKeyVault(); kvErr == nil && kvRefreshToken != "" && kvRefreshToken != refreshToken {
-			retryReqBodyObj := AccessTokenRenewReq{AccessToken: accessToken, RefreshToken: kvRefreshToken}
-			retryReqBody, _ := json.Marshal(&retryReqBodyObj)
-			respBody, err = execHttpRequestErr(url, http.MethodPost, JSON, retryReqBody, JSON, accessToken, 0)
-		}
-	}
 	if err != nil {
 		if fallbackErr := fallbackBootstrapOnRenewFailure(); fallbackErr == nil {
 			return nil

--- a/commvault/provider.go
+++ b/commvault/provider.go
@@ -3,6 +3,7 @@ package commvault
 import (
 	"os"
 	"strconv"
+	"strings"
 
 	"terraform-provider-commvault/commvault/handler"
 
@@ -39,7 +40,14 @@ func Provider() *schema.Provider {
 			"api_token": {
 				Type:        schema.TypeString,
 				Optional:    true,
-				Description: "Specifies the encrypted token for the user to authentication to Web Server.",
+				Sensitive:   true,
+				Description: "Bootstrap token for initial /V4/AccessToken call. Can be expired if refresh_token is provided.",
+			},
+			"refresh_token": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				Sensitive:   true,
+				Description: "Optional recovery refresh token used only when api_token bootstrap fails with 401 and no valid cached token is available.",
 			},
 			"logging": {
 				Type:        schema.TypeBool,
@@ -141,6 +149,7 @@ func providerConfigure(data *schema.ResourceData) (i interface{}, err error) {
 	username := data.Get("user_name").(string)
 	password := data.Get("password").(string)
 	api_token := data.Get("api_token").(string)
+	refresh_token := data.Get("refresh_token").(string)
 	logging := data.Get("logging").(bool)
 	ignore_cert := data.Get("ignore_cert").(bool)
 
@@ -151,13 +160,38 @@ func providerConfigure(data *schema.ResourceData) (i interface{}, err error) {
 	os.Setenv("IGNORE_CERT", strconv.FormatBool(ignore_cert))
 
 	if api_token != "" {
-		os.Setenv("AuthToken", api_token)
+		os.Setenv("CV_BOOTSTRAP_TOKEN", api_token)
+		// Token-based auth: try cache first, then bootstrap
+
+		// Step 1: Try to load cached tokens if available
+		if cached, _ := handler.TryUseCachedTokens(); cached {
+			// Cache hit - proceed with cached tokens.
+			// Do not overwrite cached refresh token with user input.
+		} else {
+			// Step 2: Cache miss - bootstrap new token pair from api_token
+			if tokenErr := handler.CreateAccessTokenWithBootstrapToken(api_token); tokenErr != nil {
+				// Bootstrap failed - try refresh token recovery if available
+				if refresh_token != "" && strings.Contains(tokenErr.Error(), "401") {
+					if renewErr := handler.TryRenewWithExpiredTokenAndRefresh(api_token, refresh_token); renewErr != nil {
+						return nil, renewErr
+					}
+				} else {
+					return nil, tokenErr
+				}
+			}
+		}
 	} else if os.Getenv("CV_TER_TOKEN") != "" {
 		os.Setenv("AuthToken", os.Getenv("CV_TER_TOKEN"))
+		os.Setenv("CV_REFRESH_TOKEN", "")
+		os.Setenv("CV_BOOTSTRAP_TOKEN", "")
 	} else if os.Getenv("CV_TER_PASSWORD") != "" {
 		handler.LoginWithProviderCredentials(username, os.Getenv("CV_TER_PASSWORD"))
+		os.Setenv("CV_REFRESH_TOKEN", "")
+		os.Setenv("CV_BOOTSTRAP_TOKEN", "")
 	} else {
 		handler.LoginWithProviderCredentials(username, password)
+		os.Setenv("CV_REFRESH_TOKEN", "")
+		os.Setenv("CV_BOOTSTRAP_TOKEN", "")
 	}
 
 	if data.Get("company") != nil {

--- a/commvault/provider.go
+++ b/commvault/provider.go
@@ -1,6 +1,7 @@
 package commvault
 
 import (
+	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -21,13 +22,14 @@ func Provider() *schema.Provider {
 			},
 			"user_name": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
 				DefaultFunc: schema.EnvDefaultFunc("CV_USERNAME", os.Getenv("CV_USERNAME")),
 				Description: "Specifies the User name used for authentication to Web Server",
 			},
 			"password": {
 				Type:        schema.TypeString,
-				Required:    true,
+				Optional:    true,
+				Sensitive:   true,
 				DefaultFunc: schema.EnvDefaultFunc("CV_PASSWORD", os.Getenv("CV_PASSWORD")),
 				Description: "Specifies the Password for the user name to authentication to Web Server.",
 			},
@@ -48,6 +50,36 @@ func Provider() *schema.Provider {
 				Optional:    true,
 				Sensitive:   true,
 				Description: "Optional recovery refresh token used only when api_token bootstrap fails with 401 and no valid cached token is available.",
+			},
+			"key_vault_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_NAME", os.Getenv("CV_KEY_VAULT_NAME")),
+				Description: "Optional Azure Key Vault name used to resolve missing credentials and tokens.",
+			},
+			"key_vault_user_name_secret_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_USER_NAME_SECRET", os.Getenv("CV_KEY_VAULT_USER_NAME_SECRET")),
+				Description: "Optional Azure Key Vault secret name for user_name.",
+			},
+			"key_vault_password_secret_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_PASSWORD_SECRET", os.Getenv("CV_KEY_VAULT_PASSWORD_SECRET")),
+				Description: "Optional Azure Key Vault secret name for password.",
+			},
+			"key_vault_api_token_secret_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_API_TOKEN_SECRET", os.Getenv("CV_KEY_VAULT_API_TOKEN_SECRET")),
+				Description: "Optional Azure Key Vault secret name for api_token.",
+			},
+			"key_vault_refresh_token_secret_name": {
+				Type:        schema.TypeString,
+				Optional:    true,
+				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_REFRESH_TOKEN_SECRET", os.Getenv("CV_KEY_VAULT_REFRESH_TOKEN_SECRET")),
+				Description: "Optional Azure Key Vault secret name for refresh_token.",
 			},
 			"logging": {
 				Type:        schema.TypeBool,
@@ -150,14 +182,52 @@ func providerConfigure(data *schema.ResourceData) (i interface{}, err error) {
 	password := data.Get("password").(string)
 	api_token := data.Get("api_token").(string)
 	refresh_token := data.Get("refresh_token").(string)
+	keyVaultName := data.Get("key_vault_name").(string)
+	keyVaultUsernameSecretName := data.Get("key_vault_user_name_secret_name").(string)
+	keyVaultPasswordSecretName := data.Get("key_vault_password_secret_name").(string)
+	keyVaultAPITokenSecretName := data.Get("key_vault_api_token_secret_name").(string)
+	keyVaultRefreshTokenSecretName := data.Get("key_vault_refresh_token_secret_name").(string)
 	logging := data.Get("logging").(bool)
 	ignore_cert := data.Get("ignore_cert").(bool)
 
+	// Set Key Vault env vars first so FetchAzureKeyVaultSecret can use them below.
 	os.Setenv("CV_CSIP", cvUrl)
-	os.Setenv("CV_USERNAME", username)
-	os.Setenv("CV_PASSWORD", password)
 	os.Setenv("CV_LOGGING", strconv.FormatBool(logging))
 	os.Setenv("IGNORE_CERT", strconv.FormatBool(ignore_cert))
+	os.Setenv("CV_KEY_VAULT_NAME", keyVaultName)
+	os.Setenv("CV_KEY_VAULT_USER_NAME_SECRET", keyVaultUsernameSecretName)
+	os.Setenv("CV_KEY_VAULT_PASSWORD_SECRET", keyVaultPasswordSecretName)
+	os.Setenv("CV_KEY_VAULT_API_TOKEN_SECRET", keyVaultAPITokenSecretName)
+	os.Setenv("CV_KEY_VAULT_REFRESH_TOKEN_SECRET", keyVaultRefreshTokenSecretName)
+
+	// Resolve credentials from Key Vault when inline values are empty.
+	if username == "" && keyVaultUsernameSecretName != "" {
+		if kvVal, kvErr := handler.FetchAzureKeyVaultSecret(keyVaultUsernameSecretName); kvErr == nil && kvVal != "" {
+			username = kvVal
+		}
+	}
+	if password == "" && keyVaultPasswordSecretName != "" {
+		if kvVal, kvErr := handler.FetchAzureKeyVaultSecret(keyVaultPasswordSecretName); kvErr == nil && kvVal != "" {
+			password = kvVal
+		}
+	}
+	if api_token == "" && keyVaultAPITokenSecretName != "" {
+		if kvVal, kvErr := handler.FetchAzureKeyVaultSecret(keyVaultAPITokenSecretName); kvErr == nil && kvVal != "" {
+			api_token = kvVal
+		}
+	}
+	if refresh_token == "" && keyVaultRefreshTokenSecretName != "" {
+		if kvVal, kvErr := handler.FetchAzureKeyVaultSecret(keyVaultRefreshTokenSecretName); kvErr == nil && kvVal != "" {
+			refresh_token = kvVal
+		}
+	}
+
+	os.Setenv("CV_USERNAME", username)
+	os.Setenv("CV_PASSWORD", password)
+
+	if api_token == "" && os.Getenv("CV_TER_TOKEN") == "" && os.Getenv("CV_TER_PASSWORD") == "" && (username == "" || password == "") {
+		return nil, fmt.Errorf("authentication requires either api_token or both user_name and password")
+	}
 
 	if api_token != "" {
 		os.Setenv("CV_BOOTSTRAP_TOKEN", api_token)
@@ -170,13 +240,30 @@ func providerConfigure(data *schema.ResourceData) (i interface{}, err error) {
 		} else {
 			// Step 2: Cache miss - bootstrap new token pair from api_token
 			if tokenErr := handler.CreateAccessTokenWithBootstrapToken(api_token); tokenErr != nil {
-				// Bootstrap failed - try refresh token recovery if available
-				if refresh_token != "" && strings.Contains(tokenErr.Error(), "401") {
-					if renewErr := handler.TryRenewWithExpiredTokenAndRefresh(api_token, refresh_token); renewErr != nil {
-						return nil, renewErr
+				if strings.Contains(tokenErr.Error(), "Access token creation not allowed using another access token") {
+					// The supplied api_token is already an access token; use it directly.
+					os.Setenv("AuthToken", api_token)
+					if refresh_token != "" {
+						os.Setenv("CV_REFRESH_TOKEN", refresh_token)
 					}
 				} else {
-					return nil, tokenErr
+				// Bootstrap failed - try refresh token recovery if available.
+				// If refresh token is not provided inline, lazily fetch it from Key Vault only on 401.
+					if strings.Contains(tokenErr.Error(), "401") {
+						if refresh_token == "" {
+							if kvRefreshToken, kvErr := handler.TryLoadRefreshTokenFromKeyVault(); kvErr == nil && kvRefreshToken != "" {
+								refresh_token = kvRefreshToken
+							}
+						}
+					}
+
+					if refresh_token != "" && strings.Contains(tokenErr.Error(), "401") {
+						if renewErr := handler.TryRenewWithExpiredTokenAndRefresh(api_token, refresh_token); renewErr != nil {
+							return nil, renewErr
+						}
+					} else {
+						return nil, tokenErr
+					}
 				}
 			}
 		}

--- a/commvault/provider.go
+++ b/commvault/provider.go
@@ -49,37 +49,7 @@ func Provider() *schema.Provider {
 				Type:        schema.TypeString,
 				Optional:    true,
 				Sensitive:   true,
-				Description: "Optional recovery refresh token used only when api_token bootstrap fails with 401 and no valid cached token is available.",
-			},
-			"key_vault_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_NAME", os.Getenv("CV_KEY_VAULT_NAME")),
-				Description: "Optional Azure Key Vault name used to resolve missing credentials and tokens.",
-			},
-			"key_vault_user_name_secret_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_USER_NAME_SECRET", os.Getenv("CV_KEY_VAULT_USER_NAME_SECRET")),
-				Description: "Optional Azure Key Vault secret name for user_name.",
-			},
-			"key_vault_password_secret_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_PASSWORD_SECRET", os.Getenv("CV_KEY_VAULT_PASSWORD_SECRET")),
-				Description: "Optional Azure Key Vault secret name for password.",
-			},
-			"key_vault_api_token_secret_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_API_TOKEN_SECRET", os.Getenv("CV_KEY_VAULT_API_TOKEN_SECRET")),
-				Description: "Optional Azure Key Vault secret name for api_token.",
-			},
-			"key_vault_refresh_token_secret_name": {
-				Type:        schema.TypeString,
-				Optional:    true,
-				DefaultFunc: schema.EnvDefaultFunc("CV_KEY_VAULT_REFRESH_TOKEN_SECRET", os.Getenv("CV_KEY_VAULT_REFRESH_TOKEN_SECRET")),
-				Description: "Optional Azure Key Vault secret name for refresh_token.",
+				Description: "Optional recovery refresh token used when api_token bootstrap fails with 401.",
 			},
 			"logging": {
 				Type:        schema.TypeBool,
@@ -182,48 +152,14 @@ func providerConfigure(data *schema.ResourceData) (i interface{}, err error) {
 	password := data.Get("password").(string)
 	api_token := data.Get("api_token").(string)
 	refresh_token := data.Get("refresh_token").(string)
-	keyVaultName := data.Get("key_vault_name").(string)
-	keyVaultUsernameSecretName := data.Get("key_vault_user_name_secret_name").(string)
-	keyVaultPasswordSecretName := data.Get("key_vault_password_secret_name").(string)
-	keyVaultAPITokenSecretName := data.Get("key_vault_api_token_secret_name").(string)
-	keyVaultRefreshTokenSecretName := data.Get("key_vault_refresh_token_secret_name").(string)
 	logging := data.Get("logging").(bool)
 	ignore_cert := data.Get("ignore_cert").(bool)
 
-	// Set Key Vault env vars first so FetchAzureKeyVaultSecret can use them below.
 	os.Setenv("CV_CSIP", cvUrl)
-	os.Setenv("CV_LOGGING", strconv.FormatBool(logging))
-	os.Setenv("IGNORE_CERT", strconv.FormatBool(ignore_cert))
-	os.Setenv("CV_KEY_VAULT_NAME", keyVaultName)
-	os.Setenv("CV_KEY_VAULT_USER_NAME_SECRET", keyVaultUsernameSecretName)
-	os.Setenv("CV_KEY_VAULT_PASSWORD_SECRET", keyVaultPasswordSecretName)
-	os.Setenv("CV_KEY_VAULT_API_TOKEN_SECRET", keyVaultAPITokenSecretName)
-	os.Setenv("CV_KEY_VAULT_REFRESH_TOKEN_SECRET", keyVaultRefreshTokenSecretName)
-
-	// Resolve credentials from Key Vault when inline values are empty.
-	if username == "" && keyVaultUsernameSecretName != "" {
-		if kvVal, kvErr := handler.FetchAzureKeyVaultSecret(keyVaultUsernameSecretName); kvErr == nil && kvVal != "" {
-			username = kvVal
-		}
-	}
-	if password == "" && keyVaultPasswordSecretName != "" {
-		if kvVal, kvErr := handler.FetchAzureKeyVaultSecret(keyVaultPasswordSecretName); kvErr == nil && kvVal != "" {
-			password = kvVal
-		}
-	}
-	if api_token == "" && keyVaultAPITokenSecretName != "" {
-		if kvVal, kvErr := handler.FetchAzureKeyVaultSecret(keyVaultAPITokenSecretName); kvErr == nil && kvVal != "" {
-			api_token = kvVal
-		}
-	}
-	if refresh_token == "" && keyVaultRefreshTokenSecretName != "" {
-		if kvVal, kvErr := handler.FetchAzureKeyVaultSecret(keyVaultRefreshTokenSecretName); kvErr == nil && kvVal != "" {
-			refresh_token = kvVal
-		}
-	}
-
 	os.Setenv("CV_USERNAME", username)
 	os.Setenv("CV_PASSWORD", password)
+	os.Setenv("CV_LOGGING", strconv.FormatBool(logging))
+	os.Setenv("IGNORE_CERT", strconv.FormatBool(ignore_cert))
 
 	if api_token == "" && os.Getenv("CV_TER_TOKEN") == "" && os.Getenv("CV_TER_PASSWORD") == "" && (username == "" || password == "") {
 		return nil, fmt.Errorf("authentication requires either api_token or both user_name and password")
@@ -239,16 +175,7 @@ func providerConfigure(data *schema.ResourceData) (i interface{}, err error) {
 					os.Setenv("CV_REFRESH_TOKEN", refresh_token)
 				}
 			} else {
-			// Bootstrap failed - try refresh token recovery if available.
-			// If refresh token is not provided inline, lazily fetch it from Key Vault only on 401.
-				if strings.Contains(tokenErr.Error(), "401") {
-					if refresh_token == "" {
-						if kvRefreshToken, kvErr := handler.TryLoadRefreshTokenFromKeyVault(); kvErr == nil && kvRefreshToken != "" {
-							refresh_token = kvRefreshToken
-						}
-					}
-				}
-
+				// Bootstrap failed - try refresh-token recovery on 401 when refresh_token is provided.
 				if refresh_token != "" && strings.Contains(tokenErr.Error(), "401") {
 					if renewErr := handler.TryRenewWithExpiredTokenAndRefresh(api_token, refresh_token); renewErr != nil {
 						return nil, renewErr

--- a/commvault/provider.go
+++ b/commvault/provider.go
@@ -231,39 +231,30 @@ func providerConfigure(data *schema.ResourceData) (i interface{}, err error) {
 
 	if api_token != "" {
 		os.Setenv("CV_BOOTSTRAP_TOKEN", api_token)
-		// Token-based auth: try cache first, then bootstrap
+		if tokenErr := handler.CreateAccessTokenWithBootstrapToken(api_token); tokenErr != nil {
+			if strings.Contains(tokenErr.Error(), "Access token creation not allowed using another access token") {
+				// The supplied api_token is already an access token; use it directly.
+				os.Setenv("AuthToken", api_token)
+				if refresh_token != "" {
+					os.Setenv("CV_REFRESH_TOKEN", refresh_token)
+				}
+			} else {
+			// Bootstrap failed - try refresh token recovery if available.
+			// If refresh token is not provided inline, lazily fetch it from Key Vault only on 401.
+				if strings.Contains(tokenErr.Error(), "401") {
+					if refresh_token == "" {
+						if kvRefreshToken, kvErr := handler.TryLoadRefreshTokenFromKeyVault(); kvErr == nil && kvRefreshToken != "" {
+							refresh_token = kvRefreshToken
+						}
+					}
+				}
 
-		// Step 1: Try to load cached tokens if available
-		if cached, _ := handler.TryUseCachedTokens(); cached {
-			// Cache hit - proceed with cached tokens.
-			// Do not overwrite cached refresh token with user input.
-		} else {
-			// Step 2: Cache miss - bootstrap new token pair from api_token
-			if tokenErr := handler.CreateAccessTokenWithBootstrapToken(api_token); tokenErr != nil {
-				if strings.Contains(tokenErr.Error(), "Access token creation not allowed using another access token") {
-					// The supplied api_token is already an access token; use it directly.
-					os.Setenv("AuthToken", api_token)
-					if refresh_token != "" {
-						os.Setenv("CV_REFRESH_TOKEN", refresh_token)
+				if refresh_token != "" && strings.Contains(tokenErr.Error(), "401") {
+					if renewErr := handler.TryRenewWithExpiredTokenAndRefresh(api_token, refresh_token); renewErr != nil {
+						return nil, renewErr
 					}
 				} else {
-				// Bootstrap failed - try refresh token recovery if available.
-				// If refresh token is not provided inline, lazily fetch it from Key Vault only on 401.
-					if strings.Contains(tokenErr.Error(), "401") {
-						if refresh_token == "" {
-							if kvRefreshToken, kvErr := handler.TryLoadRefreshTokenFromKeyVault(); kvErr == nil && kvRefreshToken != "" {
-								refresh_token = kvRefreshToken
-							}
-						}
-					}
-
-					if refresh_token != "" && strings.Contains(tokenErr.Error(), "401") {
-						if renewErr := handler.TryRenewWithExpiredTokenAndRefresh(api_token, refresh_token); renewErr != nil {
-							return nil, renewErr
-						}
-					} else {
-						return nil, tokenErr
-					}
+					return nil, tokenErr
 				}
 			}
 		}

--- a/docs/index.md
+++ b/docs/index.md
@@ -21,13 +21,6 @@ provider "commvault" {
 	api_token = "access token to be used"
 	refresh_token = "refresh token used to renew api_token"
 
-	# Optional Azure Key Vault settings
-	key_vault_name = "azure-key-vault-name"
-	key_vault_user_name_secret_name = "secret-name-for-user-name"
-	key_vault_password_secret_name = "secret-name-for-password"
-	key_vault_api_token_secret_name = "secret-name-for-api-token"
-	key_vault_refresh_token_secret_name = "secret-name-for-refresh-token"
-
 	ignore_cert = "true/false to ignore certificate warnings for https endpoints"
 }
 ```
@@ -44,33 +37,67 @@ provider "commvault" {
 
 ## Azure Key Vault Usage
 
-Use Azure Key Vault when you do not want to place credentials directly in Terraform files.
+Use Azure Key Vault through Terraform `azurerm` provider and pass resolved secret values directly to `provider "commvault"`.
+
+The Commvault provider is vault-agnostic and does not call vault APIs directly.
 
 ### Prerequisites
 
-- Install Azure CLI on the machine where Terraform runs.
-- Run `az login` before `terraform plan` or `terraform apply`.
-- Ensure the Azure identity has Key Vault secret `get` permission.
+- Configure `azurerm` provider.
+- Ensure the Azure identity used by `azurerm` has Key Vault secret `get` permission.
 
-### Provider Configuration with Key Vault
+### Terraform Configuration with Key Vault (`azurerm`)
+
+Use this complete example as a starting point.
 
 ```
+provider "azurerm" {
+	features {}
+	subscription_id = "00000000-0000-0000-0000-000000000000"
+}
+
+data "azurerm_key_vault" "commvault" {
+	name                = "your-key-vault-name"
+	resource_group_name = "your-key-vault-resource-group"
+}
+
+data "azurerm_key_vault_secret" "api_token" {
+	name         = "commvault-api-token"
+	key_vault_id = data.azurerm_key_vault.commvault.id
+}
+
+data "azurerm_key_vault_secret" "refresh_token" {
+	name         = "commvault-refresh-token"
+	key_vault_id = data.azurerm_key_vault.commvault.id
+}
+
 provider "commvault" {
 	web_service_url = "https://webconsole.domain.com/webconsole/api"
-
-	# Optional inline values. If empty, provider reads from Key Vault.
-	user_name = ""
-	password = ""
-	api_token = ""
-	refresh_token = ""
-
-	key_vault_name = "my-kv"
-	key_vault_user_name_secret_name = "commvault-user"
-	key_vault_password_secret_name = "commvault-password"
-	key_vault_api_token_secret_name = "commvault-api-token"
-	key_vault_refresh_token_secret_name = "commvault-refresh-token"
+	api_token       = data.azurerm_key_vault_secret.api_token.value
+	refresh_token   = data.azurerm_key_vault_secret.refresh_token.value
 
 	ignore_cert = true
+}
+```
+
+If you prefer username/password from Key Vault instead of token-based authentication:
+
+```
+data "azurerm_key_vault_secret" "user_name" {
+	name         = "commvault-user-name"
+	key_vault_id = data.azurerm_key_vault.commvault.id
+}
+
+data "azurerm_key_vault_secret" "password" {
+	name         = "commvault-password"
+	key_vault_id = data.azurerm_key_vault.commvault.id
+}
+
+provider "commvault" {
+	web_service_url = "https://webconsole.domain.com/webconsole/api"
+	user_name       = data.azurerm_key_vault_secret.user_name.value
+	password        = data.azurerm_key_vault_secret.password.value
+	ignore_cert     = true
 }
 ```
 
@@ -79,7 +106,7 @@ provider "commvault" {
 For each field (`user_name`, `password`, `api_token`, `refresh_token`):
 
 1. Use inline provider value when non-empty.
-2. Use Azure Key Vault secret when inline value is empty.
+2. If using Key Vault, resolve value with Terraform data sources and pass it directly into the provider field.
 
 ### Refresh Token Notes
 
@@ -98,11 +125,6 @@ For each field (`user_name`, `password`, `api_token`, `refresh_token`):
 - `user_name` (String) Specifies the User name used for authentication to Web Server.
 - `api_token` (String) Specifies the access token for the user. Alternatively set CV_TER_TOKEN environment variable for terraform to pick it.
 - `refresh_token` (String) Specifies refresh token used to renew access token.
-- `key_vault_name` (String) Azure Key Vault name for secret lookup.
-- `key_vault_user_name_secret_name` (String) Key Vault secret name for `user_name`.
-- `key_vault_password_secret_name` (String) Key Vault secret name for `password`.
-- `key_vault_api_token_secret_name` (String) Key Vault secret name for `api_token`.
-- `key_vault_refresh_token_secret_name` (String) Key Vault secret name for `refresh_token`.
 - `ignore_cert` (Bool) true/false to ignore certificate warnings for https endpoints.
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -16,10 +16,19 @@ The Commvault Terraform provider provides a set of named resource types, and spe
 ```
 provider "commvault" {
 	web_service_url = "URL of the commserver webservice/webconsole api endpoint"
-	user_name = "username that is used to call APIs" 
+	user_name = "username that is used to call APIs"
 	password = "password in base 64 encoded format"
 	api_token = "access token to be used"
-    ignore_cert = "true/false to ignore certificate warnings for https endpoints"
+	refresh_token = "refresh token used to renew api_token"
+
+	# Optional Azure Key Vault settings
+	key_vault_name = "azure-key-vault-name"
+	key_vault_user_name_secret_name = "secret-name-for-user-name"
+	key_vault_password_secret_name = "secret-name-for-password"
+	key_vault_api_token_secret_name = "secret-name-for-api-token"
+	key_vault_refresh_token_secret_name = "secret-name-for-refresh-token"
+
+	ignore_cert = "true/false to ignore certificate warnings for https endpoints"
 }
 ```
 ## Example Usage
@@ -27,9 +36,57 @@ provider "commvault" {
 ```
 provider "commvault" {
 	web_service_url = "https://webconsole.domain.com/webconsole/api"
-	user_name       = "your-admin-username" 
+	user_name       = "your-admin-username"
 	password = "QnVebFRgciEoMg=="
+	ignore_cert = true
+}
 ```
+
+## Azure Key Vault Usage
+
+Use Azure Key Vault when you do not want to place credentials directly in Terraform files.
+
+### Prerequisites
+
+- Install Azure CLI on the machine where Terraform runs.
+- Run `az login` before `terraform plan` or `terraform apply`.
+- Ensure the Azure identity has Key Vault secret `get` permission.
+
+### Provider Configuration with Key Vault
+
+```
+provider "commvault" {
+	web_service_url = "https://webconsole.domain.com/webconsole/api"
+
+	# Optional inline values. If empty, provider reads from Key Vault.
+	user_name = ""
+	password = ""
+	api_token = ""
+	refresh_token = ""
+
+	key_vault_name = "my-kv"
+	key_vault_user_name_secret_name = "commvault-user"
+	key_vault_password_secret_name = "commvault-password"
+	key_vault_api_token_secret_name = "commvault-api-token"
+	key_vault_refresh_token_secret_name = "commvault-refresh-token"
+
+	ignore_cert = true
+}
+```
+
+### Credential Precedence
+
+For each field (`user_name`, `password`, `api_token`, `refresh_token`):
+
+1. Use inline provider value when non-empty.
+2. Use Azure Key Vault secret when inline value is empty.
+
+### Refresh Token Notes
+
+- `refresh_token` is optional, but recommended when using `api_token`.
+- If `api_token` is expired, provider attempts renewal using `refresh_token`.
+- Store both token values in Key Vault for best operational stability.
+- If renewal fails with "Renew request placed after the permissible time limit", generate a new token pair and update the Key Vault secrets.
 
 ### Required
 
@@ -39,7 +96,13 @@ provider "commvault" {
 
 - `password` (String) Specifies the Password for the user name to authentication to Web Server. Alternatively set CV_TER_PASSWORD environment variable for terraform to pick it.
 - `user_name` (String) Specifies the User name used for authentication to Web Server.
-- `api_token` (String) Specifies the access token for the user. Alternatively set CV_TER_TOKEN environment variable for terraform to pick it. 
+- `api_token` (String) Specifies the access token for the user. Alternatively set CV_TER_TOKEN environment variable for terraform to pick it.
+- `refresh_token` (String) Specifies refresh token used to renew access token.
+- `key_vault_name` (String) Azure Key Vault name for secret lookup.
+- `key_vault_user_name_secret_name` (String) Key Vault secret name for `user_name`.
+- `key_vault_password_secret_name` (String) Key Vault secret name for `password`.
+- `key_vault_api_token_secret_name` (String) Key Vault secret name for `api_token`.
+- `key_vault_refresh_token_secret_name` (String) Key Vault secret name for `refresh_token`.
 - `ignore_cert` (Bool) true/false to ignore certificate warnings for https endpoints.
 
 


### PR DESCRIPTION
Today, the terraform provider supports api_token, but the token is sent in headers as is instead of "Bearer" token.
Also, if the token expires user has to manually change the api_token in the tfvars.

Fix:

Send api_token as bearer token 
Call V4/AccessToken to get access, refresh tokens
cache them locally in file and in memory
Use access token to make api calls
Use refresh token if access token expired 
Use new user entered api_token , if refresh token also expire

