### PR TITLE
Terraform credential resource : `type` field description uses "Returns" language in a declarative config context

### DIFF
--- a/commvault/resource_vmgroup_v2.go
+++ b/commvault/resource_vmgroup_v2.go
@@ -641,7 +641,7 @@ func resourceVMGroup_V2() *schema.Resource {
                                     "type": {
                                         Type:        schema.TypeString,
                                         Optional:    true,
-                                        Description: "Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]",
+                                        Description: "Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]",
                                     },
                                     "categoryname": {
                                         Type:        schema.TypeString,

--- a/docs/resources/credential_aws.md
+++ b/docs/resources/credential_aws.md
@@ -107,7 +107,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_awswithrolearn.md
+++ b/docs/resources/credential_awswithrolearn.md
@@ -107,7 +107,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_azure.md
+++ b/docs/resources/credential_azure.md
@@ -112,7 +112,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_azurewithtenantid.md
+++ b/docs/resources/credential_azurewithtenantid.md
@@ -126,7 +126,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>


### PR DESCRIPTION
**Severity:** Low
**Affected resources:** All credential resources (via the `permissions` sub-block)
**Affected files:**
- `commvault/resource_vmgroup_v2.go` (line 644 - `Description: "Returns the type of association..."`)
- `docs/resources/credential_aws.md` (line 110)
- `docs/resources/credential_awswithrolearn.md` (line 110)
- `docs/resources/credential_azure.md` (line 115)
- `docs/resources/credential_azurewithtenantid.md` (line 129)
**Problem:**
The `type` field description says *"Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]"*. Terraform resources are declarative config - they don't "return" anything. This field specifies which association type the user wants to declare, not what the API returns.

-**Fix plan:**
1. In `commvault/resource_vmgroup_v2.go` line 644, change the description to:
`"Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]"`.
2. Regenerate docs for all credential resources and `vmgroup_v2`.
**How to test:**
- `go build ./...` to confirm compilation.
- Regenerate docs with `tfplugindocs` and verify the corrected description in all affected doc files.-
