### PR TITLE
Credential Resource -  `permissions` description uses API response language instead of configuration language

### DIFF
--- a/commvault/resource_vmgroup_v2.go
+++ b/commvault/resource_vmgroup_v2.go
@@ -641,7 +641,7 @@ func resourceVMGroup_V2() *schema.Resource {
                                     "type": {
                                         Type:        schema.TypeString,
                                         Optional:    true,
-                                        Description: "Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]",
+                                        Description: "Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]",
                                     },
                                     "categoryname": {
                                         Type:        schema.TypeString,

--- a/docs/resources/credential_aws.md
+++ b/docs/resources/credential_aws.md
@@ -107,7 +107,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_aws.md
+++ b/docs/resources/credential_aws.md
@@ -92,7 +92,7 @@ Optional:
 
 Optional:
 
-- `iscreatorassociation` (String) To check if the user/user group associated is the owner.
+- `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
 - `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))

--- a/docs/resources/credential_aws.md
+++ b/docs/resources/credential_aws.md
@@ -93,7 +93,7 @@ Optional:
 Optional:
 
 - `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
-- `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
+- `permissions` (Block List) Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the commvault_permission data source to look up permission IDs by name. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))
 

--- a/docs/resources/credential_awswithrolearn.md
+++ b/docs/resources/credential_awswithrolearn.md
@@ -107,7 +107,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_awswithrolearn.md
+++ b/docs/resources/credential_awswithrolearn.md
@@ -92,7 +92,7 @@ Optional:
 
 Optional:
 
-- `iscreatorassociation` (String) To check if the user/user group associated is the owner.
+- `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
 - `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))

--- a/docs/resources/credential_awswithrolearn.md
+++ b/docs/resources/credential_awswithrolearn.md
@@ -93,7 +93,7 @@ Optional:
 Optional:
 
 - `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
-- `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
+- `permissions` (Block List) Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the commvault_permission data source to look up permission IDs by name. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))
 

--- a/docs/resources/credential_azure.md
+++ b/docs/resources/credential_azure.md
@@ -97,7 +97,7 @@ Optional:
 
 Optional:
 
-- `iscreatorassociation` (String) To check if the user/user group associated is the owner.
+- `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
 - `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))

--- a/docs/resources/credential_azure.md
+++ b/docs/resources/credential_azure.md
@@ -112,7 +112,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_azure.md
+++ b/docs/resources/credential_azure.md
@@ -98,7 +98,7 @@ Optional:
 Optional:
 
 - `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
-- `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
+- `permissions` (Block List) Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the commvault_permission data source to look up permission IDs by name. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))
 

--- a/docs/resources/credential_azurewithtenantid.md
+++ b/docs/resources/credential_azurewithtenantid.md
@@ -111,7 +111,7 @@ Optional:
 
 Optional:
 
-- `iscreatorassociation` (String) To check if the user/user group associated is the owner.
+- `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
 - `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))

--- a/docs/resources/credential_azurewithtenantid.md
+++ b/docs/resources/credential_azurewithtenantid.md
@@ -112,7 +112,7 @@ Optional:
 Optional:
 
 - `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
-- `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
+- `permissions` (Block List) Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the commvault_permission data source to look up permission IDs by name. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))
 

--- a/docs/resources/credential_azurewithtenantid.md
+++ b/docs/resources/credential_azurewithtenantid.md
@@ -126,7 +126,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>


### PR DESCRIPTION
## BUG-CRED-002: `permissions` description uses API response language instead of configuration language

**Severity:** Medium  
**Affected resources:** `commvault_credential_aws`, `commvault_credential_awswithrolearn`, `commvault_credential_azure`, `commvault_credential_azurewithtenantid`  
**Affected files:**
- `docs/resources/credential_aws.md` (line 98)
- `docs/resources/credential_awswithrolearn.md` (line 98)
- `docs/resources/credential_azure.md` (line 103)
- `docs/resources/credential_azurewithtenantid.md` (line 117)

**Problem:**  
The description says *"Either categoryId and categoryName or permissionId and permissionName will be returned"* — this is API response documentation language, not Terraform resource configuration language. In a `.tf` file nothing is "returned"; the user declares what permissions to associate. The description does not explain:
- When to use `categoryid`/`categoryname` vs `permissionid`/`permissionname`.
- Where to find valid permission IDs/names (i.e., via the `data.commvault_permission` data source).

**Fix plan:**
1. Update the `permissions` block description in all four credential doc files to:
   `"Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the 'commvault_permission' data source to look up permission IDs by name."`.
2. If the description is auto-generated from schema code, locate the schema definition for the `permissions` block in the security association builder code and update the `Description` field there.
3. Add a usage note in the example blocks showing the `data.commvault_permission` pattern (the `credential_aws` doc already has this in the custom example, but the description itself doesn't mention it).

**How to test:**
- Regenerate docs and verify the updated description appears for all four credential resources.
- Confirm the example HCL using `data.commvault_permission` still works syntactically with `terraform validate`.

---
