### PR TITLE
Credential Resource - Boolean values defined as `schema.TypeString` instead of `schema.TypeBool`

### DIFF
--- a/commvault/resource_vmgroup_v2.go
+++ b/commvault/resource_vmgroup_v2.go
@@ -641,7 +641,7 @@ func resourceVMGroup_V2() *schema.Resource {
                                     "type": {
                                         Type:        schema.TypeString,
                                         Optional:    true,
-                                        Description: "Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]",
+                                        Description: "Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]",
                                     },
                                     "categoryname": {
                                         Type:        schema.TypeString,

--- a/docs/resources/credential_aws.md
+++ b/docs/resources/credential_aws.md
@@ -107,7 +107,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_aws.md
+++ b/docs/resources/credential_aws.md
@@ -92,7 +92,7 @@ Optional:
 
 Optional:
 
-- `iscreatorassociation` (String) To check if the user/user group associated is the owner.
+- `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
 - `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))

--- a/docs/resources/credential_aws.md
+++ b/docs/resources/credential_aws.md
@@ -93,7 +93,7 @@ Optional:
 Optional:
 
 - `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
-- `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
+- `permissions` (Block List) Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the commvault_permission data source to look up permission IDs by name. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))
 

--- a/docs/resources/credential_awswithrolearn.md
+++ b/docs/resources/credential_awswithrolearn.md
@@ -107,7 +107,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_awswithrolearn.md
+++ b/docs/resources/credential_awswithrolearn.md
@@ -92,7 +92,7 @@ Optional:
 
 Optional:
 
-- `iscreatorassociation` (String) To check if the user/user group associated is the owner.
+- `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
 - `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))

--- a/docs/resources/credential_awswithrolearn.md
+++ b/docs/resources/credential_awswithrolearn.md
@@ -93,7 +93,7 @@ Optional:
 Optional:
 
 - `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
-- `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
+- `permissions` (Block List) Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the commvault_permission data source to look up permission IDs by name. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))
 

--- a/docs/resources/credential_azure.md
+++ b/docs/resources/credential_azure.md
@@ -97,7 +97,7 @@ Optional:
 
 Optional:
 
-- `iscreatorassociation` (String) To check if the user/user group associated is the owner.
+- `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
 - `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))

--- a/docs/resources/credential_azure.md
+++ b/docs/resources/credential_azure.md
@@ -112,7 +112,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>

--- a/docs/resources/credential_azure.md
+++ b/docs/resources/credential_azure.md
@@ -98,7 +98,7 @@ Optional:
 Optional:
 
 - `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
-- `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
+- `permissions` (Block List) Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the commvault_permission data source to look up permission IDs by name. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))
 

--- a/docs/resources/credential_azurewithtenantid.md
+++ b/docs/resources/credential_azurewithtenantid.md
@@ -111,7 +111,7 @@ Optional:
 
 Optional:
 
-- `iscreatorassociation` (String) To check if the user/user group associated is the owner.
+- `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
 - `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))

--- a/docs/resources/credential_azurewithtenantid.md
+++ b/docs/resources/credential_azurewithtenantid.md
@@ -112,7 +112,7 @@ Optional:
 Optional:
 
 - `iscreatorassociation` (String) When true, marks this as a creator association. Distinct from ownership, which is set via the owner block.
-- `permissions` (Block List) List of permissions associated with the entity. Either categoryId and categoryName or permissionId and permissionName will be returned. If categoryId or categoryName is returned, all the corresponding permissions in the category are associated with the entity. (see [below for nested schema](#nestedblock--security--associations--permissions))
+- `permissions` (Block List) Permissions to associate with the entity. Specify either categoryId/categoryName to grant all permissions in a category, or permissionId/permissionName to grant a specific permission. Use the commvault_permission data source to look up permission IDs by name. (see [below for nested schema](#nestedblock--security--associations--permissions))
 - `user` (Block List) (see [below for nested schema](#nestedblock--security--associations--user))
 - `usergroup` (Block List) (see [below for nested schema](#nestedblock--security--associations--usergroup))
 

--- a/docs/resources/credential_azurewithtenantid.md
+++ b/docs/resources/credential_azurewithtenantid.md
@@ -126,7 +126,7 @@ Optional:
 - `exclude` (String) Flag to specify if this is included permission or excluded permission.
 - `permissionid` (Number)
 - `permissionname` (String)
-- `type` (String) Returns the type of association. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
+- `type` (String) Type of permission association. Use ALL_CATEGORIES to associate all permission categories, CATEGORY_ENTITY to associate a specific category, or PERMISSION_ENTITY to associate a specific permission. [ALL_CATEGORIES, CATEGORY_ENTITY, PERMISSION_ENTITY]
 
 
 <a id="nestedblock--security--associations--user"></a>


### PR DESCRIPTION
## BUG-CRED-006: Boolean values defined as `schema.TypeString` instead of `schema.TypeBool`

**Severity:** Medium  
**Affected resources:** All credential resources (via security associations), `commvault_vmgroup_v2`, and many others across the provider  
**Affected files (credential-relevant):**
- `commvault/resource_vmgroup_v2.go` — `iscreatorassociation` (line 591), `exclude` (line 639), plus dozens of other boolean-as-string fields like `enablebackup`, `enablerestore`, `overwrite`, `filtersubresource`, etc.
- All serialization functions that use `strconv.FormatBool()` to write `*bool` values into `TypeString` fields.
- Doc files for all credential resources (show `iscreatorassociation = "false"` in examples).