### PR TITLE
Kubernetes docs and description feedback

### DIFF
--- a/commvault/resource_kubernetes_appgroup.go
+++ b/commvault/resource_kubernetes_appgroup.go
@@ -301,7 +301,7 @@ func resourceKubernetes_Appgroup() *schema.Resource {
             "tags": {
                 Type:        schema.TypeSet,
                 Optional:    true,
-                Description: "",
+                Description: "Commvault entity tags (key-value metadata) on the application group resource in CommCell. Use content.labelselectors for Kubernetes label-based content selection.",
                 Elem: &schema.Resource{
                     Schema: map[string]*schema.Schema{
                         "name": {

--- a/commvault/resource_kubernetes_appgroup.go
+++ b/commvault/resource_kubernetes_appgroup.go
@@ -200,7 +200,7 @@ func resourceKubernetes_Appgroup() *schema.Resource {
                 Type:        schema.TypeList,
                 Optional:    true,
                 Computed:    true,
-                Description: "",
+                Description: "Timezone for the application group schedule. Affects when jobstarttime is evaluated. Use the commvault_timezone data source to look up the ID.",
                 Elem: &schema.Resource{
                     Schema: map[string]*schema.Schema{
                         "name": {
@@ -222,7 +222,7 @@ func resourceKubernetes_Appgroup() *schema.Resource {
                 Type:        schema.TypeList,
                 Optional:    true,
                 Computed:    true,
-                Description: "",
+                Description: "Appgroup-level operational settings including schedule start time, worker configuration, and snapshot behaviour.",
                 Elem: &schema.Resource{
                     Schema: map[string]*schema.Schema{
                         "backupstreams": {

--- a/commvault/resource_kubernetes_appgroup.go
+++ b/commvault/resource_kubernetes_appgroup.go
@@ -1,13 +1,13 @@
 package commvault
 
 import (
-    "fmt"
-    "strconv"
-    "strings"
+	"fmt"
+	"strconv"
+	"strings"
 
-    "terraform-provider-commvault/commvault/handler"
+	"terraform-provider-commvault/commvault/handler"
 
-    "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceKubernetes_Appgroup() *schema.Resource {
@@ -235,7 +235,7 @@ func resourceKubernetes_Appgroup() *schema.Resource {
                             Type:        schema.TypeString,
                             Optional:    true,
                             Computed:    true,
-                            Description: "Define setting to enable scheduling worker Pods to CV Namespace for CSI-Snapshot enabled backups",
+                            Description: "When true, schedules worker Pods into the Commvault config namespace (confignamespace). Enable for CSI snapshot-based backups so the worker can access VolumeSnapshot CRDs. See also: options.workernamespace, cluster options.confignamespace.",
                         },
                         "workerresources": {
                             Type:        schema.TypeList,

--- a/commvault/resource_kubernetes_appgroup.go
+++ b/commvault/resource_kubernetes_appgroup.go
@@ -293,7 +293,7 @@ func resourceKubernetes_Appgroup() *schema.Resource {
                             Type:        schema.TypeInt,
                             Optional:    true,
                             Computed:    true,
-                            Description: "Define the backup job start time in epochs",
+                            Description: "Offset from midnight in seconds at which the backup job starts each day (e.g. 66540 = 18:29:00). Use with the timezone field.",
                         },
                     },
                 },

--- a/commvault/resource_kubernetes_cluster.go
+++ b/commvault/resource_kubernetes_cluster.go
@@ -1,13 +1,13 @@
 package commvault
 
 import (
-    "fmt"
-    "strconv"
-    "strings"
+	"fmt"
+	"strconv"
+	"strings"
 
-    "terraform-provider-commvault/commvault/handler"
+	"terraform-provider-commvault/commvault/handler"
 
-    "github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 )
 
 func resourceKubernetes_Cluster() *schema.Resource {
@@ -254,7 +254,7 @@ func resourceKubernetes_Cluster() *schema.Resource {
             "tags": {
                 Type:        schema.TypeSet,
                 Optional:    true,
-                Description: "Modify or add tags on the cluster",
+                Description: "Commvault entity tags (key-value metadata) on the cluster resource in CommCell. These are not Kubernetes labels and do not affect backup content selection.",
                 Elem: &schema.Resource{
                     Schema: map[string]*schema.Schema{
                         "name": {

--- a/docs/resources/kubernetes_appgroup.md
+++ b/docs/resources/kubernetes_appgroup.md
@@ -401,7 +401,7 @@ Optional:
 
 - `backupstreams` (Number) Define number of parallel data readers
 - `scheduleworkertoconfignamespace` (String) When true, schedules worker Pods into the Commvault config namespace (confignamespace). Enable for CSI snapshot-based backups so the worker can access VolumeSnapshot CRDs. See also: options.workernamespace, cluster options.confignamespace.
-- `jobstarttime` (Number) Define the backup job start time in epochs
+- `jobstarttime` (Number) Offset from midnight in seconds at which the backup job starts each day (e.g. 66540 = 18:29:00). Use with the timezone field.
 - `snapfallbacktolivevolumebackup` (String) Define setting to enable fallback to live volume backup in case of snap failure
 - `workerresources` (Block List) (see [below for nested schema](#nestedblock--options--workerresources))
 

--- a/docs/resources/kubernetes_appgroup.md
+++ b/docs/resources/kubernetes_appgroup.md
@@ -291,9 +291,9 @@ resource "commvault_kubernetes_appgroup" "kubernetes_appgroup2" {
 ### Optional
 - `activitycontrol` (Block List) (see [below for nested schema](#nestedblock--activitycontrol))
 - `filters` (Block List) (see [below for nested schema](#nestedblock--filters))
-- `options` (Block List) (see [below for nested schema](#nestedblock--options))
+- `options` (Block List) Appgroup-level operational settings including schedule start time, worker configuration, and snapshot behaviour. (see [below for nested schema](#nestedblock--options))
 - `tags` (Block Set) (see [below for nested schema](#nestedblock--tags))
-- `timezone` (Block List) (see [below for nested schema](#nestedblock--timezone))
+- `timezone` (Block List) Timezone for the application group schedule. Affects when jobstarttime is evaluated. Use the commvault_timezone data source to look up the ID. (see [below for nested schema](#nestedblock--timezone))
 
 ### Read-Only
 

--- a/docs/resources/kubernetes_appgroup.md
+++ b/docs/resources/kubernetes_appgroup.md
@@ -322,6 +322,18 @@ Read-Only:
 <a id="nestedblock--content"></a>
 ### Nested Schema for `content`
 
+`content` controls which Kubernetes resources are included in the backup. Three modes are supported:
+
+- **`applications` only** — explicit selection by GUID. Use `commvault_kubernetes_namespaces`,
+  `commvault_kubernetes_applications`, or `commvault_kubernetes_volumes` data sources to obtain the GUID,
+  or construct it manually as `` namespace`Kind`name`<k8s-uid> ``.
+- **`labelselectors` only** — dynamic selection. Any Kubernetes resource matching the given labels
+  at backup time is included. Useful for namespace-level or workload-level coverage without listing GUIDs.
+- **Both combined** — the union of all matched resources is protected.
+
+The `filters` block is the exclusion counterpart to `content`: resources matching `filters` are removed
+from the final backup scope regardless of what `content` selects.
+
 Optional:
 
 - `applications` (Block Set) List of applications to be added as content (see [below for nested schema](#nestedblock--content--applications))

--- a/docs/resources/kubernetes_appgroup.md
+++ b/docs/resources/kubernetes_appgroup.md
@@ -400,7 +400,7 @@ Required:
 Optional:
 
 - `backupstreams` (Number) Define number of parallel data readers
-- `cvnamespacescheduling` (String) Define setting to enable scheduling worker Pods to CV Namespace for CSI-Snapshot enabled backups
+- `scheduleworkertoconfignamespace` (String) When true, schedules worker Pods into the Commvault config namespace (confignamespace). Enable for CSI snapshot-based backups so the worker can access VolumeSnapshot CRDs. See also: options.workernamespace, cluster options.confignamespace.
 - `jobstarttime` (Number) Define the backup job start time in epochs
 - `snapfallbacktolivevolumebackup` (String) Define setting to enable fallback to live volume backup in case of snap failure
 - `workerresources` (Block List) (see [below for nested schema](#nestedblock--options--workerresources))

--- a/docs/resources/kubernetes_appgroup.md
+++ b/docs/resources/kubernetes_appgroup.md
@@ -13,11 +13,17 @@ Use the commvault_kubernetes_appgroup resource type to create or delete kubernet
 ## Example Usage
 
 **Configure commvault kubernetes appgroup with required fields**
+
+Each `commvault_kubernetes_*` data source requires a live cluster ID, so the cluster resource
+must be created first. Data sources resolve Kubernetes object GUIDs by name at plan time.
+
 ```hcl
+# Access node (MediaAgent) that communicates with the cluster API server
 data "commvault_client" "access_node1" {
   name = "client1"
 }
 
+# Backup plan that defines the RPO and retention for this application group
 data "commvault_plan" "plan1" {
   name = "AWS-Test-Plan"
 }
@@ -33,28 +39,33 @@ resource "commvault_kubernetes_cluster" "kubernetes_cluster1" {
   }
 }
 
+# Resolves the GUID of a specific pod by name and namespace
 data "commvault_kubernetes_applications" "kubernetes_applications" {
   name      = "my-pod"
   clusterid =  commvault_kubernetes_cluster.kubernetes_cluster1.id
   namespace = "default"
 }
 
+# Resolves the GUID of a Kubernetes label selector
 data "commvault_kubernetes_labels" "kubernetes_labels" {
   name      = "modifierAt=12655"
   clusterid = commvault_kubernetes_cluster.kubernetes_cluster1.id
   namespace = "default"
 }
 
+# Resolves the GUID of a namespace by name
 data "commvault_kubernetes_namespaces" "kubernetes_namespaces" {
   name      = "1sts-volctemplate"
   clusterid = commvault_kubernetes_cluster.kubernetes_cluster1.id
 }
 
+# Resolves the GUID of a StorageClass by name
 data "commvault_kubernetes_storageclasses" "kubernetes_storageclasses" {
   name      = "rook-ceph-block"
   clusterid = commvault_kubernetes_cluster.kubernetes_cluster1.id
 }
 
+# Resolves the GUID of a PersistentVolumeClaim by name and namespace
 data "commvault_kubernetes_volumes" "kubernetes_volumes" {
   name      = "mysql-pvc"
   clusterid = commvault_kubernetes_cluster.kubernetes_cluster1.id
@@ -107,23 +118,32 @@ resource "commvault_kubernetes_appgroup" "kubernetes_appgroup1" {
 ```
 
 **Configure commvault kubernetes appgroup with custom fields**
+
+This example shows optional fields: `filters`, `activitycontrol`, `timezone`, and `options`.
+Data sources are scoped to the cluster created in the same config block.
+
 ```hcl
+# Access node (MediaAgent) for the cluster
 data "commvault_client" "access_node1" {
   name = "bdcsrvtest05"
 }
 
+# Plan used for etcd protection on the cluster
 data "commvault_plan" "plan1" {
   name = "AWS-Test-Plan"
 }
 
+# Region to associate with the cluster
 data "commvault_region"   "region1" {
   name = "Australia"
 }
 
+# Backup plan for the application group
 data "commvault_plan" "plan2" {
   name = "Demo Plan"
 }
 
+# Timezone used to interpret jobstarttime (seconds from midnight)
 data "commvault_timezone" "timezone2" {
   name = "Singapore Standard Time"
 }
@@ -171,22 +191,26 @@ data "commvault_kubernetes_applications" "kubernetes_applications" {
   namespace = "default"
 }
 
+# Resolves the GUID of a Kubernetes label selector
 data "commvault_kubernetes_labels" "kubernetes_labels" {
   name      = "modifierAt=12655"
   clusterid = commvault_kubernetes_cluster.kubernetes_cluster2.id
   namespace = "default"
 }
 
+# Resolves the GUID of a namespace by name
 data "commvault_kubernetes_namespaces" "kubernetes_namespaces" {
   name      = "1sts-volctemplate"
   clusterid = commvault_kubernetes_cluster.kubernetes_cluster2.id
 }
 
+# Resolves the GUID of a StorageClass by name
 data "commvault_kubernetes_storageclasses" "kubernetes_storageclasses" {
   name      = "rook-ceph-block"
   clusterid = commvault_kubernetes_cluster.kubernetes_cluster2.id
 }
 
+# Resolves the GUID of a PersistentVolumeClaim by name and namespace
 data "commvault_kubernetes_volumes" "kubernetes_volumes" {
   name      = "mysql-pvc"
   clusterid = commvault_kubernetes_cluster.kubernetes_cluster2.id

--- a/docs/resources/kubernetes_appgroup.md
+++ b/docs/resources/kubernetes_appgroup.md
@@ -292,7 +292,7 @@ resource "commvault_kubernetes_appgroup" "kubernetes_appgroup2" {
 - `activitycontrol` (Block List) (see [below for nested schema](#nestedblock--activitycontrol))
 - `filters` (Block List) (see [below for nested schema](#nestedblock--filters))
 - `options` (Block List) Appgroup-level operational settings including schedule start time, worker configuration, and snapshot behaviour. (see [below for nested schema](#nestedblock--options))
-- `tags` (Block Set) (see [below for nested schema](#nestedblock--tags))
+- `tags` (Block Set) Commvault entity tags (key-value metadata) on the application group resource in CommCell. Use content.labelselectors for Kubernetes label-based content selection. (see [below for nested schema](#nestedblock--tags))
 - `timezone` (Block List) Timezone for the application group schedule. Affects when jobstarttime is evaluated. Use the commvault_timezone data source to look up the ID. (see [below for nested schema](#nestedblock--timezone))
 
 ### Read-Only

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -99,7 +99,7 @@ resource "commvault_kubernetes_cluster" "kubernetes_cluster2" {
 - `options` (Block List) Request definition for cluster advanced options (see [below for nested schema](#nestedblock--options))
 - `region` (Block List) (see [below for nested schema](#nestedblock--region))
 - `servicetype` (String) The Service Type of the Kubernetes cluster [ONPREM, AKS]
-- `tags` (Block Set) Modify or add tags on the cluster (see [below for nested schema](#nestedblock--tags))
+- `tags` (Block Set) Commvault entity tags (key-value metadata) on the cluster resource in CommCell. These are not Kubernetes labels and do not affect backup content selection. (see [below for nested schema](#nestedblock--tags))
 
 ### Read-Only
 


### PR DESCRIPTION
### BUG-K8S-011 · Example is dense with prerequisite data sources, none of them commented

**Regression Risk:** 0/10

**Files**
- `docs/resources/kubernetes_appgroup.md` — both example blocks

**Issue**
The "required fields" example references five data sources (`commvault_client`, `commvault_plan`, `commvault_kubernetes_applications`, `commvault_kubernetes_labels`, `commvault_kubernetes_namespaces`, `commvault_kubernetes_storageclasses`, `commvault_kubernetes_volumes`) without any inline comments explaining their purpose or how to obtain the referenced names.

**Fix Plan**
1. Add a comment above each data source block explaining what it represents and why it is needed, e.g.:
   ```hcl
   # Access node used to communicate with the cluster API server
   data "commvault_client" "access_node1" { ... }
   # Backup plan that defines RPO/retention for this application group
   data "commvault_plan" "plan1" { ... }
   ```
2. Add a brief prose paragraph before the example blocks explaining the dependency chain.
3. Consider splitting the minimal example (required fields only, no data sources) from a full-featured example to reduce noise.

**Test Plan**
- Docs-only change; review that each data source block has a comment and that the prose intro is accurate.

---

### BUG-K8S-014 · `content.applications` and `content.labelselectors` combinations are undocumented

**Regression Risk:** 0/10

**Files**
- `docs/resources/kubernetes_appgroup.md` — `content` nested schema

**Issue**
There is no guidance on whether `applications` and `labelselectors` inside `content` can be combined, whether they are mutually exclusive, or which combination is recommended for common use cases (e.g. "protect all namespaces matching a label" vs. "protect specific named namespaces").

**Fix Plan**
1. Add a prose section in the docs under the `content` schema heading describing the three content modes:
   - `applications` only — explicit GUID-based selection.
   - `labelselectors` only — dynamic label-based selection.
   - Both combined — union of matched resources.
2. Add a short example for each mode.
3. Clarify how `filters` interacts with `content` (exclusion vs. inclusion).

**Test Plan**
- Docs-only; validate by applying one config for each mode and confirming the expected namespaces/apps are included in the backup.

---

### BUG-K8S-018 · `options.scheduleworkertoconfignamespace` description is incomprehensible

**Regression Risk:** 0/10

**Files**
- `commvault/resource_kubernetes_appgroup.go` — `options → scheduleworkertoconfignamespace` description
- `docs/resources/kubernetes_appgroup.md`

**Issue**
Current description: `"Define setting to enable scheduling worker Pods to CV Namespace for CSI-Snapshot enabled backups"`. This is syntactically unclear ("scheduling worker Pods to CV Namespace") and does not explain the *effect* or *when* to enable it.

**Fix Plan**
1. Rewrite the description: `"When true, schedules worker Pods into the Commvault configuration namespace (confignamespace). Required when using CSI snapshot-based backups so that the worker has access to the VolumeSnapshot CRDs deployed in that namespace."`.
2. Add a cross-reference to `options.workernamespace` and to the cluster-level `options.confignamespace` so the user understands the relationship.

**Test Plan**
- Docs-only change; validate by setting the flag and confirming worker pods land in the correct namespace.

---

### BUG-K8S-019 · `options.jobstarttime` description says "epochs" but the field is seconds from midnight

**Regression Risk:** 0/10

**Files**
- `commvault/resource_kubernetes_appgroup.go` — `options → jobstarttime` description
- `docs/resources/kubernetes_appgroup.md`

**Issue**
Current description: `"Define the backup job start time in epochs"`. The example uses `jobstarttime = 66540`, which is `18:29:00` expressed as seconds from midnight (not a Unix epoch). Using an actual epoch (e.g. `1700000000`) would yield a meaningless or broken schedule.

**Fix Plan**
1. Update description: `"Offset from midnight in seconds at which the backup job should start each day. For example, 66540 = 18:29:00 (18 hours × 3600 + 29 minutes × 60). Must be used in conjunction with the timezone field."`.
2. Update any related docs prose.

**Test Plan**
- Apply `jobstarttime = 3600` (01:00:00) with a known timezone; confirm the schedule start time in CommCell matches 01:00 in that timezone.
- Confirm the existing example value `66540` maps to ~18:29 as expected.

---

### BUG-K8S-012 · `timezone` and `options` on appgroup have no context explaining their purpose

**Regression Risk:** 0/10

**Files**
- `commvault/resource_kubernetes_appgroup.go` — `timezone` and `options` schema descriptions (both empty strings)
- `docs/resources/kubernetes_appgroup.md`

**Issue**
`timezone` and `options` appear on the appgroup resource with empty descriptions. Users cannot determine whether these are K8s-specific fields, properties of an underlying Commvault schedule, or inherited from a plan. `options.jobstarttime` specifically implies schedule behaviour, yet there is no mention of schedules anywhere in the resource.

**Fix Plan**
1. `timezone` description: `"Timezone for the application group schedule. Affects when jobstarttime is evaluated. Use the commvault_timezone data source to look up the ID."`.
2. `options` description: `"Appgroup-level operational settings, including schedule start time, worker configuration, and snapshot behaviour."`.
3. Add a note clarifying the relationship with the assigned plan's schedule: does `jobstarttime` override the plan schedule, supplement it, or only apply when no plan schedule is set?

**Test Plan**
- Set `timezone` to a known ID and `options.jobstarttime` to a specific offset; confirm the job start time reflects the timezone-adjusted value via the API GET response.

---

### BUG-K8S-010 · `tags` semantics on `commvault_kubernetes_cluster` are ambiguous

**Regression Risk:** 0/10

**Files**
- `commvault/resource_kubernetes_cluster.go` — `tags` schema, description is empty
- `commvault/resource_kubernetes_appgroup.go` — `tags` schema, description is also empty
- `docs/resources/kubernetes_cluster.md`, `docs/resources/kubernetes_appgroup.md`

**Issue**
The word "tags" is overloaded in the Kubernetes context: it can mean Commvault entity tags (metadata on the Commvault resource itself) or Kubernetes label selectors used to filter backup content. No description or docs note distinguishes them. The current schema description on the cluster resource reads `"Modify or add tags on the cluster"` — still not explicit about whether these are Commvault entity tags or K8s labels.

**Fix Plan**
1. Clarify in code and docs that `tags` on `commvault_kubernetes_cluster` are **Commvault entity tags** (key-value metadata stored in CommCell, not Kubernetes labels).
2. Update cluster description: `"Commvault entity tags (key-value metadata) to apply to the cluster resource in CommCell. These are not Kubernetes labels and do not affect backup content selection."`.
3. For `commvault_kubernetes_appgroup`, apply a similar clarification: `"Commvault entity tags on the application group resource in CommCell. Use content.labelselectors for Kubernetes label-based content selection."`.

**Test Plan**
- Confirm tags set here appear in the CommCell entity tag view and not as Kubernetes label selectors.
- Confirm that `content.labelselectors` is the correct mechanism for K8s label filtering (should already work — this is a docs-only test).

---
