### PR TITLE
Terraform K8s Resource `enablebackupafteradelay` silently ignored when `enablebackup = true`

### DIFF
--- a/commvault/resource_kubernetes_appgroup.go
+++ b/commvault/resource_kubernetes_appgroup.go
@@ -65,7 +65,7 @@ func resourceKubernetes_Appgroup() *schema.Resource {
                                     "guid": {
                                         Type:        schema.TypeString,
                                         Required:    true,
-                                        Description: "GUID value of the Kubernetes Application to be associated as content",
+                                        Description: "GUID of the Kubernetes resource as tracked by CommCell. Retrieve via the commvault_kubernetes_namespaces, commvault_kubernetes_applications, or commvault_kubernetes_volumes data source. For unsupported types, construct manually: namespace`Kind`name`<k8s-uid>.",
                                     },
                                     "name": {
                                         Type:        schema.TypeString,
@@ -140,7 +140,7 @@ func resourceKubernetes_Appgroup() *schema.Resource {
                                     "guid": {
                                         Type:        schema.TypeString,
                                         Required:    true,
-                                        Description: "GUID value of the Kubernetes Application to be associated as content",
+                                        Description: "GUID of the Kubernetes resource as tracked by CommCell. Retrieve via the commvault_kubernetes_namespaces, commvault_kubernetes_applications, or commvault_kubernetes_volumes data source. For unsupported types, construct manually: namespace`Kind`name`<k8s-uid>.",
                                     },
                                     "name": {
                                         Type:        schema.TypeString,

--- a/commvault/resource_kubernetes_cluster.go
+++ b/commvault/resource_kubernetes_cluster.go
@@ -77,7 +77,7 @@ func resourceKubernetes_Cluster() *schema.Resource {
                 Type:        schema.TypeString,
                 Optional:    true,
                 Computed:    true,
-                Description: "The Service Type of the Kubernetes cluster [ONPREM, AKS]",
+                Description: "Service type of the Kubernetes cluster. Omit to let the server infer the type. Accepted values: ONPREM (on-premises), AKS (Azure Kubernetes Service), EKS (Amazon Elastic Kubernetes Service), GKE (Google Kubernetes Engine), OKE (Oracle Kubernetes Engine), TANZU, RANCHER, OPENSHIFT.",
             },
             "etcdprotection": {
                 Type:        schema.TypeList,

--- a/commvault/resource_kubernetes_cluster.go
+++ b/commvault/resource_kubernetes_cluster.go
@@ -134,7 +134,7 @@ func resourceKubernetes_Cluster() *schema.Resource {
                             Type:        schema.TypeInt,
                             Optional:    true,
                             Computed:    true,
-                            Description: "Enabling backup after a delay. Provide UTC Time in Unix format",
+                            Description: "UTC Unix timestamp after which backup will be automatically re-enabled. Only takes effect when enablebackup = \"false\"; ignored when enablebackup = \"true\".",
                         },
                         "enablebackup": {
                             Type:        schema.TypeString,
@@ -146,7 +146,7 @@ func resourceKubernetes_Cluster() *schema.Resource {
                             Type:        schema.TypeInt,
                             Optional:    true,
                             Computed:    true,
-                            Description: "Enabling restore after a delay. Provide UTC Time in Unix format",
+                            Description: "UTC Unix timestamp after which restore will be automatically re-enabled. Only takes effect when enablerestore = \"false\"; ignored when enablerestore = \"true\".",
                         },
                         "enablerestore": {
                             Type:        schema.TypeString,

--- a/docs/resources/kubernetes_appgroup.md
+++ b/docs/resources/kubernetes_appgroup.md
@@ -344,7 +344,7 @@ Optional:
 
 Required:
 
-- `guid` (String) GUID value of the Kubernetes Application to be associated as content
+- `guid` (String) GUID of the Kubernetes resource as tracked by CommCell. Retrieve via the `commvault_kubernetes_namespaces`, `commvault_kubernetes_applications`, or `commvault_kubernetes_volumes` data source. For unsupported types, construct manually: `` namespace`Kind`name`<k8s-uid> ``.
 - `type` (String) Type of the Kubernetes application [NAMESPACE, APPLICATION, PVC, LABELS]
 
 Optional:
@@ -376,7 +376,7 @@ Optional:
 
 Required:
 
-- `guid` (String) GUID value of the Kubernetes Application to be associated as content
+- `guid` (String) GUID of the Kubernetes resource as tracked by CommCell. Retrieve via the `commvault_kubernetes_namespaces`, `commvault_kubernetes_applications`, or `commvault_kubernetes_volumes` data source. For unsupported types, construct manually: `` namespace`Kind`name`<k8s-uid> ``.
 - `type` (String) Type of the Kubernetes application [NAMESPACE, APPLICATION, PVC, LABELS]
 
 Optional:

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -123,9 +123,9 @@ Read-Only:
 Optional:
 
 - `enablebackup` (String) Enable or disable backup for cluster
-- `enablebackupafteradelay` (Number) Enabling backup after a delay. Provide UTC Time in Unix format
+- `enablebackupafteradelay` (Number) UTC Unix timestamp after which backup will be automatically re-enabled. Only takes effect when `enablebackup = "false"`; ignored when `enablebackup = "true"`.
 - `enablerestore` (String) Enable or disable restore for cluster
-- `enablerestoreafteradelay` (Number) Enabling restore after a delay. Provide UTC Time in Unix format
+- `enablerestoreafteradelay` (Number) UTC Unix timestamp after which restore will be automatically re-enabled. Only takes effect when `enablerestore = "false"`; ignored when `enablerestore = "true"`.
 
 
 <a id="nestedblock--etcdprotection"></a>

--- a/docs/resources/kubernetes_cluster.md
+++ b/docs/resources/kubernetes_cluster.md
@@ -98,7 +98,7 @@ resource "commvault_kubernetes_cluster" "kubernetes_cluster2" {
 - `etcdprotection` (Block List) ETCD Protection options for a cluster (see [below for nested schema](#nestedblock--etcdprotection))
 - `options` (Block List) Request definition for cluster advanced options (see [below for nested schema](#nestedblock--options))
 - `region` (Block List) (see [below for nested schema](#nestedblock--region))
-- `servicetype` (String) The Service Type of the Kubernetes cluster [ONPREM, AKS]
+- `servicetype` (String) Service type of the Kubernetes cluster. Omit to let the server infer the type. Accepted values: `ONPREM` (on-premises), `AKS` (Azure Kubernetes Service), `EKS` (Amazon Elastic Kubernetes Service), `GKE` (Google Kubernetes Engine), `OKE` (Oracle Kubernetes Engine), `TANZU`, `RANCHER`, `OPENSHIFT`.
 - `tags` (Block Set) Commvault entity tags (key-value metadata) on the cluster resource in CommCell. These are not Kubernetes labels and do not affect backup content selection. (see [below for nested schema](#nestedblock--tags))
 
 ### Read-Only


### PR DESCRIPTION
### BUG-K8S-004 · `enablebackupafteradelay` silently ignored when `enablebackup = true`

**Regression Risk:** 1/10

**Files**
- `commvault/resource_kubernetes_cluster.go` — `activitycontrol` schema
- `docs/resources/kubernetes_cluster.md` — `activitycontrol` nested schema

**Issue**
`enablebackupafteradelay` (a Unix UTC timestamp) is only meaningful when `enablebackup = false`. When `enablebackup = true` the delay value is disregarded or may cause unexpected behaviour. The same logic applies to `enablerestoreafteradelay`. Neither the description nor any validation communicates this dependency.

**Fix Plan**
1. Update the `enablebackupafteradelay` description: `"UTC Unix timestamp after which backup will be re-enabled. Only applicable when enablebackup = false."`.
2. Do the same for `enablerestoreafteradelay`.
3. Optionally add a `ValidateFunc` or a `CustomizeDiff` that emits a warning/error when both `enablebackup = true` and `enablebackupafteradelay` are set simultaneously.

**Test Plan**
- Apply a config with `enablebackup = "true"` and a non-zero `enablebackupafteradelay`; confirm current API behaviour (silently ignores it or returns an error).
- Apply a config with `enablebackup = "false"` and a valid future Unix timestamp; confirm the API schedules the re-enable correctly.
- Run `terraform plan` after the scheduled time passes; confirm no unexpected drift.

---
